### PR TITLE
Add puzzle game page with image upload

### DIFF
--- a/PuzzleAM.View/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM.View/Components/Pages/PuzzleGame.razor
@@ -1,0 +1,25 @@
+@page "/puzzlegame"
+@rendermode InteractiveServer
+
+<PageTitle>Puzzle Game</PageTitle>
+
+<InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
+
+@if (!string.IsNullOrEmpty(imageDataUrl))
+{
+    <div style="margin-top:1rem;border:1px solid #ccc;width:400px;height:400px;display:flex;align-items:center;justify-content:center;">
+        <img src="@imageDataUrl" alt="Uploaded image" style="max-width:100%;max-height:100%;" />
+    </div>
+}
+
+@code {
+    private string? imageDataUrl;
+
+    private async Task OnInputFileChange(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        var buffer = new byte[file.Size];
+        await file.OpenReadStream(10 * 1024 * 1024).ReadAsync(buffer); // limit 10 MB
+        imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(buffer)}";
+    }
+}

--- a/PuzzleAM.View/PuzzleAM.View.csproj
+++ b/PuzzleAM.View/PuzzleAM.View.csproj
@@ -25,6 +25,9 @@
     <Content Include="Components\Pages\Home.razor">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
+    <Content Include="Components\Pages\PuzzleGame.razor">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
     <Content Include="Components\Pages\Weather.razor">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>


### PR DESCRIPTION
## Summary
- add Puzzle Game razor page with image upload button and preview box
- include new page in project file for publishing

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c7667e6c8320b142eef085963f67