### PR TITLE
refactor: move PuzzleGame code to code-behind

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -11,15 +11,3 @@
         <img src="@imageDataUrl" alt="Uploaded image" style="max-width:100%;max-height:100%;" />
     </div>
 }
-
-@code {
-    private string? imageDataUrl;
-
-    private async Task OnInputFileChange(InputFileChangeEventArgs e)
-    {
-        var file = e.File;
-        var buffer = new byte[file.Size];
-        await file.OpenReadStream(10 * 1024 * 1024).ReadAsync(buffer); // limit 10 MB
-        imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(buffer)}";
-    }
-}

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace PuzzleAM.Components.Pages;
+
+public partial class PuzzleGame : ComponentBase
+{
+    private string? imageDataUrl;
+
+    private async Task OnInputFileChange(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        var buffer = new byte[file.Size];
+        await file.OpenReadStream(10 * 1024 * 1024).ReadAsync(buffer); // limit 10 MB
+        imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(buffer)}";
+    }
+}
+


### PR DESCRIPTION
## Summary
- separate PuzzleGame logic from markup with code-behind
- keep Razor component focused on rendering

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b8ccc888108320aa62b47329fc5042