### PR TITLE
Center uploaded puzzle image at half-screen size

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -7,7 +7,7 @@
 
 @if (!string.IsNullOrEmpty(imageDataUrl))
 {
-    <div style="margin-top:1rem;border:1px solid #ccc;width:400px;height:400px;display:flex;align-items:center;justify-content:center;">
-        <img src="@imageDataUrl" alt="Uploaded image" style="max-width:100%;max-height:100%;" />
+    <div style="width:100%;height:100vh;display:flex;align-items:center;justify-content:center;">
+        <img src="@imageDataUrl" alt="Uploaded image" style="width:50vw;height:50vh;object-fit:contain;" />
     </div>
 }


### PR DESCRIPTION
## Summary
- Center uploaded puzzle image vertically and horizontally
- Size the image to occupy half of the viewport using flex and viewport units

## Testing
- ⚠️ `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d2bc155083209403682e1aa2e58e