### PR TITLE
Add jigsaw segmentation for uploaded images

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -5,9 +5,6 @@
 
 <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
 
-@if (!string.IsNullOrEmpty(imageDataUrl))
-{
-    <div style="width:100%;height:100vh;display:flex;align-items:center;justify-content:center;">
-        <img src="@imageDataUrl" alt="Uploaded image" style="width:50vw;height:50vh;object-fit:contain;" />
-    </div>
-}
+<div id="puzzleContainer"></div>
+
+<script src="puzzle.js"></script>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
 
 namespace PuzzleAM.Components.Pages;
 
 public partial class PuzzleGame : ComponentBase
 {
     private string? imageDataUrl;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {
@@ -14,6 +16,7 @@ public partial class PuzzleGame : ComponentBase
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);        // ensures the full file is read
         imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
+        await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer");
     }
 }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1,0 +1,86 @@
+window.createPuzzle = function (imageDataUrl, containerId) {
+    const img = new Image();
+    img.onload = function () {
+        const cols = 10;
+        const rows = 10;
+        const pieceWidth = img.width / cols;
+        const pieceHeight = img.height / rows;
+        const container = document.getElementById(containerId);
+        container.innerHTML = '';
+        container.style.position = 'relative';
+        container.style.width = img.width + 'px';
+        container.style.height = img.height + 'px';
+
+        const hTabs = Array.from({ length: rows }, () => Array(cols));
+        const vTabs = Array.from({ length: rows }, () => Array(cols));
+        const offset = Math.min(pieceWidth, pieceHeight) / 4;
+
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                const top = y === 0 ? 0 : -vTabs[y - 1][x];
+                const left = x === 0 ? 0 : -hTabs[y][x - 1];
+                const right = x === cols - 1 ? 0 : (hTabs[y][x] = Math.random() > 0.5 ? 1 : -1);
+                const bottom = y === rows - 1 ? 0 : (vTabs[y][x] = Math.random() > 0.5 ? 1 : -1);
+
+                const piece = document.createElement('canvas');
+                piece.width = pieceWidth + offset * 2;
+                piece.height = pieceHeight + offset * 2;
+                piece.style.position = 'absolute';
+                piece.style.left = x * pieceWidth + 'px';
+                piece.style.top = y * pieceHeight + 'px';
+
+                const ctx = piece.getContext('2d');
+                drawPiecePath(ctx, pieceWidth, pieceHeight, top, right, bottom, left, offset);
+                ctx.clip();
+                ctx.drawImage(img, offset - x * pieceWidth, offset - y * pieceHeight);
+                ctx.stroke();
+                container.appendChild(piece);
+            }
+        }
+    };
+    img.src = imageDataUrl;
+};
+
+function drawPiecePath(ctx, w, h, top, right, bottom, left, offset) {
+    const tab = Math.min(w, h) / 4;
+    ctx.beginPath();
+    ctx.moveTo(offset, offset);
+
+    // top edge
+    if (top === 0) {
+        ctx.lineTo(offset + w, offset);
+    } else {
+        ctx.lineTo(offset + w / 3, offset);
+        ctx.bezierCurveTo(offset + w / 6, offset - tab * top, offset + w * 5 / 6, offset - tab * top, offset + w * 2 / 3, offset);
+        ctx.lineTo(offset + w, offset);
+    }
+
+    // right edge
+    if (right === 0) {
+        ctx.lineTo(offset + w, offset + h);
+    } else {
+        ctx.lineTo(offset + w, offset + h / 3);
+        ctx.bezierCurveTo(offset + w + tab * right, offset + h / 6, offset + w + tab * right, offset + h * 5 / 6, offset + w, offset + h * 2 / 3);
+        ctx.lineTo(offset + w, offset + h);
+    }
+
+    // bottom edge
+    if (bottom === 0) {
+        ctx.lineTo(offset, offset + h);
+    } else {
+        ctx.lineTo(offset + w * 2 / 3, offset + h);
+        ctx.bezierCurveTo(offset + w * 5 / 6, offset + h + tab * bottom, offset + w / 6, offset + h + tab * bottom, offset + w / 3, offset + h);
+        ctx.lineTo(offset, offset + h);
+    }
+
+    // left edge
+    if (left === 0) {
+        ctx.lineTo(offset, offset);
+    } else {
+        ctx.lineTo(offset, offset + h * 2 / 3);
+        ctx.bezierCurveTo(offset - tab * left, offset + h * 5 / 6, offset - tab * left, offset + h / 6, offset, offset + h / 3);
+        ctx.lineTo(offset, offset);
+    }
+
+    ctx.closePath();
+}


### PR DESCRIPTION
## Summary
- Segment uploaded image into 10x10 jigsaw pieces via new JavaScript helper
- Trigger puzzle generation when a file is uploaded
- Display puzzle pieces in dedicated container

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d41dd6cc8320bdfac6a747d91eec