### PR TITLE
Add shadow styling for puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -58,3 +58,13 @@ h1:focus {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+.puzzle-container {
+    position: relative;
+}
+
+.puzzle-piece {
+    position: absolute;
+    cursor: grab;
+    box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.5);
+}

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -5,7 +5,7 @@ window.createPuzzle = function (imageDataUrl, containerId) {
         const rows = 10;
         const container = document.getElementById(containerId);
         container.innerHTML = '';
-        container.style.position = 'relative';
+        container.classList.add('puzzle-container');
 
         // Scale the image so that it occupies 50% of the page width
         const targetWidth = window.innerWidth * 0.5;
@@ -36,8 +36,7 @@ window.createPuzzle = function (imageDataUrl, containerId) {
                 const piece = document.createElement('canvas');
                 piece.width = pieceWidth + offset * 2;
                 piece.height = pieceHeight + offset * 2;
-                piece.style.position = 'absolute';
-                piece.style.cursor = 'grab';
+                piece.classList.add('puzzle-piece');
 
                 // Randomize starting position to separate the pieces
                 piece.style.left = Math.random() * (scaledWidth - pieceWidth) + 'px';


### PR DESCRIPTION
## Summary
- give puzzle pieces a 3D effect by styling them in CSS and applying classes

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bd40bb548320addc1c461552c95c