### PR TITLE
Use drop-shadow for puzzle piece edges

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -66,5 +66,5 @@ h1:focus {
 .puzzle-piece {
     position: absolute;
     cursor: grab;
-    box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.5);
+    filter: drop-shadow(3px 3px 6px rgba(0, 0, 0, 0.5));
 }


### PR DESCRIPTION
## Summary
- Replace rectangular box-shadow with drop-shadow filter so puzzle piece shadows follow jigsaw contours

## Testing
- `dotnet build PuzzleAM.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9beed31ec83209d7f816cab299bac