### PR TITLE
Add puzzle piece count dropdown

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -3,6 +3,13 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
+<select @bind="selectedPieces" class="form-select">
+    @foreach (var option in PieceOptions)
+    {
+        <option value="@option">@option</option>
+    }
+</select>
+
 <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
 
 <div id="puzzleContainer"></div>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -8,6 +8,8 @@ public partial class PuzzleGame : ComponentBase
 {
     private string? imageDataUrl;
     [Inject] private IJSRuntime JS { get; set; } = default!;
+    private int selectedPieces = 100;
+    private static readonly int[] PieceOptions = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {
@@ -16,7 +18,7 @@ public partial class PuzzleGame : ComponentBase
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);        // ensures the full file is read
         imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
-        await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer");
+        await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer", selectedPieces);
     }
 }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1,8 +1,11 @@
-window.createPuzzle = function (imageDataUrl, containerId) {
+window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
     const img = new Image();
     img.onload = function () {
-        const cols = 10;
-        const rows = 10;
+        let cols = Math.round(Math.sqrt(pieceCount));
+        while (pieceCount % cols !== 0) {
+            cols--;
+        }
+        const rows = pieceCount / cols;
         const container = document.getElementById(containerId);
         container.innerHTML = '';
         container.classList.add('puzzle-container');


### PR DESCRIPTION
## Summary
- add dropdown to choose number of puzzle pieces
- segment image using selected piece count

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0f610fc8320bff78b0644f8fbda