### PR TITLE
Add canvas background to puzzle game

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -12,6 +12,8 @@
 
 <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
 
-<div id="puzzleContainer"></div>
+<div id="puzzleContainer">
+    <canvas id="backgroundCanvas" class="puzzle-background"></canvas>
+</div>
 
 <script src="puzzle.js"></script>

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -63,8 +63,16 @@ h1:focus {
     position: relative;
 }
 
+.puzzle-background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
 .puzzle-piece {
     position: absolute;
     cursor: grab;
     filter: drop-shadow(3px 3px 6px rgba(0, 0, 0, 0.5));
+    z-index: 1;
 }

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -9,8 +9,19 @@ window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
         }
         const rows = pieceCount / cols;
         const container = document.getElementById(containerId);
-        container.innerHTML = '';
         container.classList.add('puzzle-container');
+
+        // Remove any existing puzzle pieces but keep the background canvas
+        container.querySelectorAll('.puzzle-piece').forEach(p => p.remove());
+
+        // Ensure a background canvas exists
+        let background = container.querySelector('#backgroundCanvas');
+        if (!background) {
+            background = document.createElement('canvas');
+            background.id = 'backgroundCanvas';
+            background.classList.add('puzzle-background');
+            container.appendChild(background);
+        }
 
         // Scale the image so that it occupies 50% of the page width
         const targetWidth = window.innerWidth * 0.5;
@@ -27,6 +38,13 @@ window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
 
         container.style.width = scaledWidth + 'px';
         container.style.height = scaledHeight + 'px';
+
+        // Draw the scaled image on the background canvas
+        background.width = scaledWidth;
+        background.height = scaledHeight;
+        const bgCtx = background.getContext('2d');
+        bgCtx.clearRect(0, 0, scaledWidth, scaledHeight);
+        bgCtx.drawImage(img, 0, 0, scaledWidth, scaledHeight);
 
         const hTabs = Array.from({ length: rows }, () => Array(cols));
         const vTabs = Array.from({ length: rows }, () => Array(cols));


### PR DESCRIPTION
## Summary
- Add background canvas to puzzle game page
- Render scaled puzzle image on canvas behind pieces
- Style background and puzzle pieces for proper layering

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d066f34c8320af6470bee5318f8b