### PR TITLE
Add full-page textured background

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -1,5 +1,26 @@
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    height: 100%;
+}
+
+body {
+    margin: 0;
+    background-color: #f5f5f5;
+    background-image: repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.02),
+            rgba(0, 0, 0, 0.02) 1px,
+            transparent 1px,
+            transparent 40px
+        ),
+        repeating-linear-gradient(
+            90deg,
+            rgba(0, 0, 0, 0.02),
+            rgba(0, 0, 0, 0.02) 1px,
+            transparent 1px,
+            transparent 40px
+        );
+    background-size: 40px 40px;
 }
 
 a, .btn-link {


### PR DESCRIPTION
## Summary
- Add textured linen-like background to body to cover the entire page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d2663fec8320874cc83231b0dcc4