### PR TITLE
Remove background puzzle image canvas

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -12,8 +12,6 @@
 
 <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
 
-<div id="puzzleContainer">
-    <canvas id="backgroundCanvas" class="puzzle-background"></canvas>
-</div>
+<div id="puzzleContainer"></div>
 
 <script src="puzzle.js"></script>

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -84,13 +84,6 @@ h1:focus {
     position: relative;
 }
 
-.puzzle-background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    pointer-events: none;
-}
-
 .puzzle-piece {
     position: absolute;
     cursor: grab;

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -11,17 +11,8 @@ window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
         const container = document.getElementById(containerId);
         container.classList.add('puzzle-container');
 
-        // Remove any existing puzzle pieces but keep the background canvas
-        container.querySelectorAll('.puzzle-piece').forEach(p => p.remove());
-
-        // Ensure a background canvas exists
-        let background = container.querySelector('#backgroundCanvas');
-        if (!background) {
-            background = document.createElement('canvas');
-            background.id = 'backgroundCanvas';
-            background.classList.add('puzzle-background');
-            container.appendChild(background);
-        }
+        // Clear any existing puzzle elements
+        container.innerHTML = '';
 
         // Scale the image so that it occupies 50% of the page width
         const targetWidth = window.innerWidth * 0.5;
@@ -38,13 +29,6 @@ window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
 
         container.style.width = scaledWidth + 'px';
         container.style.height = scaledHeight + 'px';
-
-        // Draw the scaled image on the background canvas
-        background.width = scaledWidth;
-        background.height = scaledHeight;
-        const bgCtx = background.getContext('2d');
-        bgCtx.clearRect(0, 0, scaledWidth, scaledHeight);
-        bgCtx.drawImage(img, 0, 0, scaledWidth, scaledHeight);
 
         const hTabs = Array.from({ length: rows }, () => Array(cols));
         const vTabs = Array.from({ length: rows }, () => Array(cols));


### PR DESCRIPTION
## Summary
- Remove background canvas from puzzle page to avoid showing full puzzle image beneath pieces
- Simplify puzzle logic to stop drawing image on hidden canvas and only render puzzle pieces
- Drop unused CSS for background canvas

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b9d45fc12c83208a0ddfb6fe79a259