### PR TITLE
Add canvas background color selector and rearrange controls

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -3,14 +3,22 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
-<select @bind="selectedPieces" class="form-select">
-    @foreach (var option in PieceOptions)
-    {
-        <option value="@option">@option</option>
-    }
-</select>
+<div class="d-flex align-items-center gap-2 mb-3">
+    <select @bind="selectedPieces" class="form-select w-auto">
+        @foreach (var option in PieceOptions)
+        {
+            <option value="@option">@option</option>
+        }
+    </select>
 
-<InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
+    <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
+
+    <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select w-auto">
+        <option value="#EFECE6">#EFECE6</option>
+        <option value="#E7F1DC">#E7F1DC</option>
+        <option value="#C8D2C5">#C8D2C5</option>
+    </select>
+</div>
 
 <div id="puzzleContainer"></div>
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -10,6 +10,20 @@ public partial class PuzzleGame : ComponentBase
     [Inject] private IJSRuntime JS { get; set; } = default!;
     private int selectedPieces = 100;
     private static readonly int[] PieceOptions = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
+    private string selectedBackground = "#EFECE6";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+        }
+    }
+
+    private async Task OnBackgroundChange()
+    {
+        await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+    }
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1,5 +1,12 @@
 window.pieces = [];
 
+window.setBackgroundColor = function (color) {
+    const container = document.getElementById('puzzleContainer');
+    if (container) {
+        container.style.backgroundColor = color;
+    }
+};
+
 window.createPuzzle = function (imageDataUrl, containerId, pieceCount) {
     const img = new Image();
     img.onload = function () {


### PR DESCRIPTION
## Summary
- Align puzzle piece selector with image import control in a single horizontal row
- Add background color dropdown for puzzle canvas with three selectable shades
- Implement JS helper to apply selected canvas background color dynamically

## Testing
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d6a9efa88320a71830ff056b7a61