### PR TITLE
Move background color to page

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -82,6 +82,7 @@ h1:focus {
 
 .puzzle-container {
     position: relative;
+    background-color: transparent;
 }
 
 .puzzle-piece {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1,9 +1,15 @@
 window.pieces = [];
 
 window.setBackgroundColor = function (color) {
+    if (document.body) {
+        document.body.style.backgroundColor = color;
+    }
+    if (document.documentElement) {
+        document.documentElement.style.backgroundColor = color;
+    }
     const container = document.getElementById('puzzleContainer');
     if (container) {
-        container.style.backgroundColor = color;
+        container.style.backgroundColor = 'transparent';
     }
 };
 


### PR DESCRIPTION
## Summary
- apply background color to page instead of puzzle area
- keep puzzle container transparent so page color shows through

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da1d98d48320af5a8d41753737fb