### PR TITLE
Spread puzzle pieces around edges for initial layout

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -85,6 +85,12 @@ h1:focus {
     background-color: transparent;
 }
 
+.puzzle-board {
+    position: absolute;
+    border: 2px dashed rgba(0, 0, 0, 0.3);
+    z-index: 0;
+}
+
 .puzzle-piece {
     position: absolute;
     cursor: grab;


### PR DESCRIPTION
## Summary
- Fill puzzle container to full screen and reserve centered assembly area
- Randomly distribute pieces around page edges without overlap
- Add dashed board outline styling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4aa49bc832091e1c43673f533bc