### PR TITLE
Add SignalR hub for multiplayer puzzle rooms

### DIFF
--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.SignalR;
+
+namespace PuzzleAM.Hubs;
+
+public class PuzzleState
+{
+    public ConcurrentDictionary<string, (int X, int Y)> Pieces { get; } = new();
+    public ConcurrentDictionary<string, byte> Participants { get; } = new();
+}
+
+public class PuzzleHub : Hub
+{
+    // Maps room codes to their puzzle state. Persist to Redis or a database for scalability if needed.
+    private static readonly ConcurrentDictionary<string, PuzzleState> Rooms = new();
+
+    public string CreateRoom()
+    {
+        var code = Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
+        Rooms[code] = new PuzzleState();
+        return code;
+    }
+
+    public async Task JoinRoom(string roomCode)
+    {
+        if (Rooms.TryGetValue(roomCode, out var state))
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
+            state.Participants[Context.ConnectionId] = 0;
+            await Clients.Caller.SendAsync("BoardState", state.Pieces);
+        }
+    }
+
+    public async Task MovePiece(string roomCode, string pieceId, int x, int y)
+    {
+        if (Rooms.TryGetValue(roomCode, out var state))
+        {
+            state.Pieces[pieceId] = (x, y);
+            await Clients.Group(roomCode).SendAsync("PieceMoved", pieceId, x, y);
+        }
+    }
+}

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -1,4 +1,5 @@
 using PuzzleAM.Components;
+using PuzzleAM.Hubs;
 using PuzzleAM.ViewServices;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddScoped<ModalService>();
+builder.Services.AddSignalR();
 
 var app = builder.Build();
 
@@ -27,5 +29,6 @@ app.UseAntiforgery();
 app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+app.MapHub<PuzzleHub>("/puzzlehub");
 
 app.Run();

--- a/PuzzleAM/PuzzleAM.csproj
+++ b/PuzzleAM/PuzzleAM.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="../PuzzleAM.ViewServices/PuzzleAM.ViewServices.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add Microsoft.AspNetCore.SignalR package and register SignalR services
- implement `PuzzleHub` with room creation, joining and piece movement
- map hub endpoint for real-time puzzle updates

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bafef296348320ba3ca4ace3c0c7e0