### PR TITLE
Add SignalR room creation and joining UI

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -4,6 +4,21 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
+<div class="mb-3">
+    <button class="btn btn-success me-2" @onclick="CreateRoom" disabled="@(!IsConnected)">Create Room</button>
+    @if (!string.IsNullOrEmpty(roomCode))
+    {
+        <span>Room Code: @roomCode</span>
+    }
+</div>
+
+<div class="mb-3">
+    <input class="form-control w-auto d-inline" @bind="joinCode" placeholder="Enter room code" />
+    <button class="btn btn-primary ms-2" @onclick="JoinRoom" disabled="@(!IsConnected)">Join Room</button>
+</div>
+
+<div class="mb-3">Connection Status: @connectionStatus</div>
+
 <div class="d-flex align-items-center gap-2 mb-3">
     <select @bind="selectedPieces" class="form-select w-auto">
         @foreach (var option in PieceOptions)

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -1,16 +1,56 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
 
 namespace PuzzleAM.Components.Pages;
 
-public partial class PuzzleGame : ComponentBase
+public partial class PuzzleGame : ComponentBase, IAsyncDisposable
 {
     private string? imageDataUrl;
     [Inject] private IJSRuntime JS { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+    private HubConnection? hubConnection;
+    private string? roomCode;
+    private string? joinCode;
+    private string connectionStatus = "Disconnected";
     private int selectedPieces = 100;
     private static readonly int[] PieceOptions = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
     private string selectedBackground = "#EFECE6";
+
+    private bool IsConnected => hubConnection?.State == HubConnectionState.Connected;
+
+    protected override async Task OnInitializedAsync()
+    {
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl(Navigation.ToAbsoluteUri("/puzzlehub"))
+            .WithAutomaticReconnect()
+            .Build();
+
+        hubConnection.Reconnecting += error =>
+        {
+            connectionStatus = "Reconnecting...";
+            InvokeAsync(StateHasChanged);
+            return Task.CompletedTask;
+        };
+
+        hubConnection.Reconnected += connectionId =>
+        {
+            connectionStatus = "Connected";
+            InvokeAsync(StateHasChanged);
+            return Task.CompletedTask;
+        };
+
+        hubConnection.Closed += error =>
+        {
+            connectionStatus = "Disconnected";
+            InvokeAsync(StateHasChanged);
+            return Task.CompletedTask;
+        };
+
+        await hubConnection.StartAsync();
+        connectionStatus = "Connected";
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -34,5 +74,34 @@ public partial class PuzzleGame : ComponentBase
         imageDataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
         await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer", selectedPieces);
     }
+
+    private async Task CreateRoom()
+    {
+        if (hubConnection is null) return;
+        roomCode = await hubConnection.InvokeAsync<string>("CreateRoom");
+    }
+
+    private async Task JoinRoom()
+    {
+        if (hubConnection is null || string.IsNullOrWhiteSpace(joinCode)) return;
+        var state = await hubConnection.InvokeAsync<PuzzleState?>("JoinRoom", joinCode);
+        if (state is not null && !string.IsNullOrEmpty(state.ImageDataUrl))
+        {
+            imageDataUrl = state.ImageDataUrl;
+            selectedPieces = state.PieceCount;
+            await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer", selectedPieces);
+            roomCode = joinCode;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (hubConnection is not null)
+        {
+            await hubConnection.DisposeAsync();
+        }
+    }
+
+    private record PuzzleState(string ImageDataUrl, int PieceCount);
 }
 

--- a/PuzzleAM/PuzzleAM.csproj
+++ b/PuzzleAM/PuzzleAM.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="../PuzzleAM.Model/PuzzleAM.Model.csproj" />
     <ProjectReference Include="../PuzzleAM.View/PuzzleAM.View.csproj" />
     <ProjectReference Include="../PuzzleAM.ViewServices/PuzzleAM.ViewServices.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add UI to create puzzle room, join by code, and show connection status
- connect to `PuzzleHub` via SignalR with automatic reconnect and room methods
- include SignalR client package reference

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bafef34bc083208028585e9dfc37c1