### PR TITLE
Refine Docker build with explicit project copies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-# Copy the project file and restore dependencies
-COPY *.csproj ./
-RUN dotnet restore
+# Copy the project and solution files and restore dependencies
+COPY PuzzleAM.sln .
+COPY PuzzleAM/*.csproj PuzzleAM/
+COPY PuzzleAM.Model/*.csproj PuzzleAM.Model/
+COPY PuzzleAM.View/*.csproj PuzzleAM.View/
+COPY PuzzleAM.ViewServices/*.csproj PuzzleAM.ViewServices/
+RUN dotnet restore PuzzleAM.sln
 
 # Copy the rest of the source and publish
 COPY . .


### PR DESCRIPTION
## Summary
- Copy solution and individual project files explicitly in Docker build stage
- Restore using the solution file for clearer dependency resolution

## Testing
- `~/.dotnet/dotnet build PuzzleAM.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bb308c245c8320971d88749db63ec7