### PR TITLE
Load puzzle script globally for PuzzleGame

### DIFF
--- a/PuzzleAM/Components/App.razor
+++ b/PuzzleAM/Components/App.razor
@@ -15,6 +15,7 @@
 
 <body>
     <Routes />
+    <script src="puzzle.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -37,5 +37,3 @@
 </div>
 
 <div id="puzzleContainer"></div>
-
-<script src="puzzle.js"></script>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -17,6 +17,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     private int selectedPieces = 100;
     private static readonly int[] PieceOptions = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
     private string selectedBackground = "#EFECE6";
+    private bool scriptLoaded;
 
     private bool IsConnected => hubConnection?.State == HubConnectionState.Connected;
 
@@ -57,12 +58,16 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         if (firstRender)
         {
             await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+            scriptLoaded = true;
         }
     }
 
     private async Task OnBackgroundChange()
     {
-        await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+        if (scriptLoaded)
+        {
+            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+        }
     }
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)


### PR DESCRIPTION
## Summary
- Load `puzzle.js` once from App.razor so it's available before component rendering
- Remove page-level script include in PuzzleGame
- Guard `setBackgroundColor` calls so they run only after the script has loaded

## Testing
- `dotnet build PuzzleAM.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bb4830ee9c8320b98c1666785d3fe1