### PR TITLE
Handle JS background color errors

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -56,13 +56,31 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+            try
+            {
+                await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+            }
+            catch (Exception ex)
+            {
+                connectionStatus = "Error setting background color";
+                Console.Error.WriteLine(ex);
+                await InvokeAsync(StateHasChanged);
+            }
         }
     }
 
     private async Task OnBackgroundChange()
     {
-        await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+        try
+        {
+            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+        }
+        catch (Exception ex)
+        {
+            connectionStatus = "Error setting background color";
+            Console.Error.WriteLine(ex);
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)


### PR DESCRIPTION
## Summary
- wrap background color JS call with try/catch to avoid 500s

## Testing
- `dotnet build PuzzleAM.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4831ddcc8320a07b2038227ca57c