### PR TITLE
Handle background color JS errors gracefully

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.JSInterop;
+using Microsoft.Extensions.Logging;
 
 namespace PuzzleAM.Components.Pages;
 
@@ -10,6 +11,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     private string? imageDataUrl;
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private ILogger<PuzzleGame> Logger { get; set; } = default!;
     private HubConnection? hubConnection;
     private string? roomCode;
     private string? joinCode;
@@ -57,8 +59,16 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
-            scriptLoaded = true;
+            try
+            {
+                await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+                scriptLoaded = true;
+            }
+            catch (Exception ex)
+            {
+                connectionStatus = "Background color error";
+                Logger.LogError(ex, "Error applying background color");
+            }
         }
     }
 
@@ -66,7 +76,15 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     {
         if (scriptLoaded)
         {
-            await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+            try
+            {
+                await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
+            }
+            catch (Exception ex)
+            {
+                connectionStatus = "Background color error";
+                Logger.LogError(ex, "Error applying background color");
+            }
         }
     }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -79,15 +79,20 @@ function sendMove(piece) {
 window.addEventListener("load", startHubConnection);
 
 window.setBackgroundColor = function (color) {
-    if (document.body) {
-        document.body.style.backgroundColor = color;
-    }
-    if (document.documentElement) {
-        document.documentElement.style.backgroundColor = color;
-    }
-    const container = document.getElementById('puzzleContainer');
-    if (container) {
-        container.style.backgroundColor = 'transparent';
+    try {
+        if (document.body) {
+            document.body.style.backgroundColor = color;
+        }
+        if (document.documentElement) {
+            document.documentElement.style.backgroundColor = color;
+        }
+        const container = document.getElementById('puzzleContainer');
+        if (container) {
+            container.style.backgroundColor = 'transparent';
+        }
+    } catch (error) {
+        console.error('Error applying background color', error);
+        throw error;
     }
 };
 


### PR DESCRIPTION
## Summary
- catch errors when applying page background color and log them
- update connection status when background color JS fails
- propagate background color failures from JS to .NET

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52c9bb0083209fb58ebc2537e61d