### PR TITLE
Remove direct SignalR server package

### DIFF
--- a/PuzzleAM/PuzzleAM.csproj
+++ b/PuzzleAM/PuzzleAM.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- drop redundant Microsoft.AspNetCore.SignalR server package and rely on framework implementation

## Testing
- `dotnet build PuzzleAM.sln -v minimal`
- `dotnet run --no-build --project PuzzleAM/PuzzleAM.csproj`
- `curl -i -X POST http://localhost:5252/puzzlehub/negotiate?negotiateVersion=1`

------
https://chatgpt.com/codex/tasks/task_e_68bb48329b288320b8c9d256acc80f7a