### PR TITLE
Add SignalR browser client to App.razor

### DIFF
--- a/PuzzleAM/Components/App.razor
+++ b/PuzzleAM/Components/App.razor
@@ -15,6 +15,7 @@
 
 <body>
     <Routes />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js"></script>
     <script src="puzzle.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- include SignalR browser client before puzzle.js in `App.razor`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb651dd68c83209e37601070dbf6be