### PR TITLE
Ensure SignalR hub path uses lowercase

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -26,7 +26,7 @@ function playClickSound() {
 
 function startHubConnection() {
     hubConnection = new signalR.HubConnectionBuilder()
-        .withUrl("/puzzleHub")
+        .withUrl("/puzzlehub")
         .withAutomaticReconnect()
         .build();
 


### PR DESCRIPTION
## Summary
- use lowercase `/puzzlehub` in client-side SignalR connection

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6df284188320b399112135f69173