### PR TITLE
Add room management and puzzle state tracking

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -100,8 +100,12 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
 
     private async Task CreateRoom()
     {
-        if (hubConnection is null) return;
-        roomCode = await hubConnection.InvokeAsync<string>("CreateRoom");
+        if (hubConnection is null || string.IsNullOrEmpty(imageDataUrl)) return;
+        roomCode = await hubConnection.InvokeAsync<string>("CreateRoom", imageDataUrl, selectedPieces);
+        if (!string.IsNullOrEmpty(roomCode))
+        {
+            await JS.InvokeVoidAsync("setRoomCode", roomCode);
+        }
     }
 
     private async Task JoinRoom()
@@ -114,6 +118,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
             selectedPieces = state.PieceCount;
             await JS.InvokeVoidAsync("createPuzzle", imageDataUrl, "puzzleContainer", selectedPieces);
             roomCode = joinCode;
+            await JS.InvokeVoidAsync("setRoomCode", roomCode);
         }
     }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -2,6 +2,7 @@ window.pieces = [];
 // Track the highest z-index so groups can be brought to the front
 window.maxZ = 1;
 let hubConnection;
+let currentRoomCode = null;
 
 // Play a short click when groups connect
 let audioCtx;
@@ -67,7 +68,7 @@ function startHubConnection() {
 
 function sendMove(piece) {
     if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
-        hubConnection.invoke("MovePiece", {
+        hubConnection.invoke("MovePiece", currentRoomCode, {
             id: parseInt(piece.dataset.pieceId),
             left: parseFloat(piece.style.left),
             top: parseFloat(piece.style.top),
@@ -77,6 +78,10 @@ function sendMove(piece) {
 }
 
 window.addEventListener("load", startHubConnection);
+
+window.setRoomCode = function (code) {
+    currentRoomCode = code;
+};
 
 window.setBackgroundColor = function (color) {
     try {


### PR DESCRIPTION
## Summary
- Add per-room `CreateRoom` and `JoinRoom` hub methods with unique codes
- Store `ImageDataUrl` and `PieceCount` in server-side `PuzzleState`
- Broadcast piece moves only to others in the same room
- Wire up client to send room code when moving pieces and handle hub changes

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68bb6df6c78c8320b999b156372e5dcf