### PR TITLE
Use shared PuzzleState model across client and server

### DIFF
--- a/PuzzleAM.Model/PuzzleState.cs
+++ b/PuzzleAM.Model/PuzzleState.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+
+namespace PuzzleAM.Model;
+
+/// <summary>
+/// Represents the position of a puzzle piece on the board.
+/// </summary>
+public record PiecePosition(int Id, float Left, float Top, int? GroupId);
+
+/// <summary>
+/// Maintains the current state of a puzzle session.
+/// </summary>
+public class PuzzleState
+{
+    /// <summary>
+    /// Gets or sets the URL containing the puzzle image data.
+    /// </summary>
+    public string? ImageDataUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of pieces the puzzle contains.
+    /// </summary>
+    public int PieceCount { get; set; }
+
+    /// <summary>
+    /// Tracks the positions of puzzle pieces by their identifier.
+    /// </summary>
+    public ConcurrentDictionary<int, PiecePosition> Pieces { get; } = new();
+}
+

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.JSInterop;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using PuzzleAM.Model;
 
 namespace PuzzleAM.Components.Pages;
 
@@ -124,7 +125,5 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
             await hubConnection.DisposeAsync();
         }
     }
-
-    private record PuzzleState(string ImageDataUrl, int PieceCount);
 }
 

--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -1,20 +1,7 @@
-using System.Collections.Concurrent;
 using Microsoft.AspNetCore.SignalR;
+using PuzzleAM.Model;
 
 namespace PuzzleAM.Hubs;
-
-/// <summary>
-/// Represents the position of a puzzle piece on the board.
-/// </summary>
-public record PiecePosition(int Id, float Left, float Top, int? GroupId);
-
-/// <summary>
-/// Maintains the current state of a puzzle session.
-/// </summary>
-public class PuzzleState
-{
-    public ConcurrentDictionary<int, PiecePosition> Pieces { get; } = new();
-}
 
 public class PuzzleHub : Hub
 {


### PR DESCRIPTION
## Summary
- add shared PuzzleState and PiecePosition models
- update PuzzleHub to use shared state for storing and broadcasting moves
- reference shared PuzzleState in PuzzleGame component

## Testing
- `dotnet build PuzzleAM.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bb6df761848320a2dc427aa19e0787