### PR TITLE
Use shared PuzzleState model across server and client

### DIFF
--- a/PuzzleAM.Model/PuzzleState.cs
+++ b/PuzzleAM.Model/PuzzleState.cs
@@ -1,0 +1,18 @@
+namespace PuzzleAM.Model;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Represents the position of a puzzle piece on the board.
+/// </summary>
+public record PiecePosition(int Id, float Left, float Top, int? GroupId);
+
+/// <summary>
+/// Maintains the current state of a puzzle session.
+/// </summary>
+public class PuzzleState
+{
+    public string ImageDataUrl { get; set; } = string.Empty;
+    public int PieceCount { get; set; }
+    public ConcurrentDictionary<int, PiecePosition> Pieces { get; } = new();
+}

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.JSInterop;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using PuzzleAM.Model;
 
 namespace PuzzleAM.Components.Pages;
 
@@ -130,6 +131,5 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         }
     }
 
-    private record PuzzleState(string ImageDataUrl, int PieceCount);
 }
 

--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -1,23 +1,9 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using Microsoft.AspNetCore.SignalR;
+using PuzzleAM.Model;
 
 namespace PuzzleAM.Hubs;
-
-/// <summary>
-/// Represents the position of a puzzle piece on the board.
-/// </summary>
-public record PiecePosition(int Id, float Left, float Top, int? GroupId);
-
-/// <summary>
-/// Maintains the current state of a puzzle session.
-/// </summary>
-public class PuzzleState
-{
-    public string ImageDataUrl { get; set; } = string.Empty;
-    public int PieceCount { get; set; }
-    public ConcurrentDictionary<int, PiecePosition> Pieces { get; } = new();
-}
 
 public class PuzzleHub : Hub
 {


### PR DESCRIPTION
## Summary
- Add shared `PuzzleState` and `PiecePosition` models in `PuzzleAM.Model` for use by server and client
- Update `PuzzleHub` to store and broadcast using the shared contract
- Point `PuzzleGame` to the shared model instead of private records

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb706ee2f4832092971626e56fbcf5