### PR TITLE
Use JavaScript-only SignalR hub connection

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -5,7 +5,7 @@
 <PageTitle>Puzzle Game</PageTitle>
 
 <div class="mb-3">
-    <button class="btn btn-success me-2" @onclick="CreateRoom" disabled="@(!IsConnected)">Create Room</button>
+    <button class="btn btn-success me-2" @onclick="CreateRoom">Create Room</button>
     @if (!string.IsNullOrEmpty(roomCode))
     {
         <span>Room Code: @roomCode</span>
@@ -14,10 +14,8 @@
 
 <div class="mb-3">
     <input class="form-control w-auto d-inline" @bind="joinCode" placeholder="Enter room code" />
-    <button class="btn btn-primary ms-2" @onclick="JoinRoom" disabled="@(!IsConnected)">Join Room</button>
+    <button class="btn btn-primary ms-2" @onclick="JoinRoom">Join Room</button>
 </div>
-
-<div class="mb-3">Connection Status: @connectionStatus</div>
 
 <div class="d-flex align-items-center gap-2 mb-3">
     <select @bind="selectedPieces" class="form-select w-auto">

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -83,6 +83,26 @@ window.setRoomCode = function (code) {
     currentRoomCode = code;
 };
 
+window.createRoom = async function (imageDataUrl, pieceCount) {
+    if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
+        const code = await hubConnection.invoke("CreateRoom", imageDataUrl, pieceCount);
+        window.setRoomCode(code);
+        return code;
+    }
+    return null;
+};
+
+window.joinRoom = async function (roomCode) {
+    if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
+        const state = await hubConnection.invoke("JoinRoom", roomCode);
+        if (state) {
+            window.setRoomCode(roomCode);
+        }
+        return state;
+    }
+    return null;
+};
+
 window.setBackgroundColor = function (color) {
     try {
         if (document.body) {


### PR DESCRIPTION
## Summary
- Switch hub communication to a single JavaScript connection with new `createRoom` and `joinRoom` helpers
- Remove C# `HubConnection` logic from `PuzzleGame` and call the JS helpers via interop
- Simplify puzzle UI by dropping connection status tracking

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71ceaa2c832090ff3074e1a4cca7