### PR TITLE
Add home page and room routing

### DIFF
--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -8,11 +8,6 @@
 
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="nav flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Puzzle Game
-            </NavLink>
-        </div>
     </nav>
 </div>
 

--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -1,0 +1,43 @@
+@page "/"
+@rendermode InteractiveServer
+@using PuzzleAM.Model
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+
+<h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
+<div class="d-flex flex-column align-items-center justify-content-center" style="height:70vh;">
+    <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>
+    <div class="input-group w-auto mb-2">
+        <input class="form-control" @bind="joinCode" placeholder="Enter room code" />
+        <button class="btn btn-primary" @onclick="JoinRoom">Join Room</button>
+    </div>
+    @if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div class="text-danger">@errorMessage</div>
+    }
+</div>
+
+@code {
+    private string? joinCode;
+    private string? errorMessage;
+
+    private async Task CreateRoom()
+    {
+        var code = await JS.InvokeAsync<string>("createRoom");
+        Nav.NavigateTo($"/puzzlegame/{code}");
+    }
+
+    private async Task JoinRoom()
+    {
+        if (string.IsNullOrWhiteSpace(joinCode)) return;
+        var state = await JS.InvokeAsync<PuzzleState?>("joinRoom", joinCode);
+        if (state is not null)
+        {
+            Nav.NavigateTo($"/puzzlegame/{joinCode}");
+        }
+        else
+        {
+            errorMessage = "Room code does not exist";
+        }
+    }
+}

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -1,21 +1,7 @@
-@page "/"
-@page "/puzzlegame"
+@page "/puzzlegame/{roomCode}"
 @rendermode InteractiveServer
 
 <PageTitle>Puzzle Game</PageTitle>
-
-<div class="mb-3">
-    <button class="btn btn-success me-2" @onclick="CreateRoom">Create Room</button>
-    @if (!string.IsNullOrEmpty(roomCode))
-    {
-        <span>Room Code: @roomCode</span>
-    }
-</div>
-
-<div class="mb-3">
-    <input class="form-control w-auto d-inline" @bind="joinCode" placeholder="Enter room code" />
-    <button class="btn btn-primary ms-2" @onclick="JoinRoom">Join Room</button>
-</div>
 
 <div class="d-flex align-items-center gap-2 mb-3">
     <select @bind="selectedPieces" class="form-select w-auto">
@@ -32,6 +18,11 @@
         <option value="#E7F1DC">#E7F1DC</option>
         <option value="#C8D2C5">#C8D2C5</option>
     </select>
+
+    @if (!string.IsNullOrEmpty(RoomCode))
+    {
+        <span>Room Code: @RoomCode</span>
+    }
 </div>
 
 <div id="puzzleContainer"></div>

--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -30,6 +30,19 @@ public class PuzzleHub : Hub
         return code;
     }
 
+    public Task<string> CreateRoom() => CreateRoom(string.Empty, 0);
+
+    public async Task SetPuzzle(string roomCode, string imageDataUrl, int pieceCount)
+    {
+        if (Rooms.TryGetValue(roomCode, out var state))
+        {
+            state.ImageDataUrl = imageDataUrl;
+            state.PieceCount = pieceCount;
+            state.Pieces.Clear();
+            await Clients.Group(roomCode).SendAsync("BoardState", state);
+        }
+    }
+
     public async Task<PuzzleState?> JoinRoom(string roomCode)
     {
         if (Rooms.TryGetValue(roomCode, out var state))

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -85,11 +85,17 @@ window.setRoomCode = function (code) {
 
 window.createRoom = async function (imageDataUrl, pieceCount) {
     if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
-        const code = await hubConnection.invoke("CreateRoom", imageDataUrl, pieceCount);
+        const code = await hubConnection.invoke("CreateRoom", imageDataUrl || "", pieceCount || 0);
         window.setRoomCode(code);
         return code;
     }
     return null;
+};
+
+window.setPuzzle = async function (roomCode, imageDataUrl, pieceCount) {
+    if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
+        await hubConnection.invoke("SetPuzzle", roomCode, imageDataUrl, pieceCount);
+    }
 };
 
 window.joinRoom = async function (roomCode) {


### PR DESCRIPTION
## Summary
- Add new home page with create/join room actions
- Route puzzle games using room code and show code near colour selector
- Support empty room creation and puzzle updates via hub

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7bf456e083209e0d17aa50519777