### PR TITLE
Fix CreateRoom duplication error by using optional parameters

### DIFF
--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -18,7 +18,7 @@ public class PuzzleHub : Hub
         return new string(Enumerable.Range(0, 6).Select(_ => chars[Random.Next(chars.Length)]).ToArray());
     }
 
-    public async Task<string> CreateRoom(string imageDataUrl, int pieceCount)
+    public async Task<string> CreateRoom(string imageDataUrl = "", int pieceCount = 0)
     {
         string code;
         do
@@ -29,8 +29,6 @@ public class PuzzleHub : Hub
         await Groups.AddToGroupAsync(Context.ConnectionId, code);
         return code;
     }
-
-    public Task<string> CreateRoom() => CreateRoom(string.Empty, 0);
 
     public async Task SetPuzzle(string roomCode, string imageDataUrl, int pieceCount)
     {


### PR DESCRIPTION
## Summary
- Remove duplicate CreateRoom hub method
- Allow optional image and piece count parameters with defaults

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7efb1b1083208a009217ea40c89a