### PR TITLE
Add leave room button to Puzzle Game

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -22,6 +22,7 @@
     @if (!string.IsNullOrEmpty(RoomCode))
     {
         <span>Room Code: @RoomCode</span>
+        <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
     }
 </div>
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -11,6 +11,7 @@ public partial class PuzzleGame : ComponentBase
     private string? imageDataUrl;
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private ILogger<PuzzleGame> Logger { get; set; } = default!;
+    [Inject] private NavigationManager Nav { get; set; } = default!;
     [Parameter] public string? RoomCode { get; set; }
     private int selectedPieces = 100;
     private static readonly int[] PieceOptions = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
@@ -72,6 +73,24 @@ public partial class PuzzleGame : ComponentBase
         if (!string.IsNullOrEmpty(RoomCode))
         {
             await JS.InvokeVoidAsync("setPuzzle", RoomCode, imageDataUrl, selectedPieces);
+        }
+    }
+
+    private async Task LeaveRoom()
+    {
+        if (joined)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("leaveRoom");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error leaving room");
+            }
+
+            joined = false;
+            Nav.NavigateTo("/");
         }
     }
 }

--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -52,6 +52,11 @@ public class PuzzleHub : Hub
         return null;
     }
 
+    public async Task LeaveRoom(string roomCode)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, roomCode);
+    }
+
     /// <summary>
     /// Persists the new position of a piece and broadcasts it to clients in the
     /// same room.

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -109,6 +109,13 @@ window.joinRoom = async function (roomCode) {
     return null;
 };
 
+window.leaveRoom = async function () {
+    if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected && currentRoomCode) {
+        await hubConnection.invoke("LeaveRoom", currentRoomCode);
+        currentRoomCode = null;
+    }
+};
+
 window.setBackgroundColor = function (color) {
     try {
         if (document.body) {


### PR DESCRIPTION
## Summary
- Add Leave Room button to puzzle page for users to exit rooms
- Disconnect and navigate home when button is clicked
- Support leaving rooms via SignalR hub and client-side helper

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bb81ed1dcc832093ee39fb057628f6