### PR TITLE
Use server-provided piece count when creating puzzles

### DIFF
--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -37,7 +37,12 @@ public class PuzzleHub : Hub
             state.ImageDataUrl = imageDataUrl;
             state.PieceCount = pieceCount;
             state.Pieces.Clear();
-            await Clients.Group(roomCode).SendAsync("BoardState", state);
+            await Clients.Group(roomCode).SendAsync("BoardState", new
+            {
+                imageDataUrl = state.ImageDataUrl,
+                pieceCount = state.PieceCount,
+                pieces = state.Pieces.Values
+            });
         }
     }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -47,7 +47,7 @@ function startHubConnection() {
 
     hubConnection.on("BoardState", state => {
         if (state.imageDataUrl && window.pieces.length === 0) {
-            window.createPuzzle(state.imageDataUrl, "puzzleContainer", state.pieces.length);
+            window.createPuzzle(state.imageDataUrl, "puzzleContainer", state.pieceCount);
         }
 
         (state.pieces || []).forEach(p => {


### PR DESCRIPTION
## Summary
- use `state.pieceCount` when initializing the puzzle on board state
- broadcast `pieceCount` with board state from the hub

## Testing
- `/root/.dotnet/dotnet test`
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bb84c4e5ac832080da6146536528ee