### PR TITLE
Fix connect sound when dragging within group

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -493,7 +493,7 @@ function snapPiece(el) {
         const pieceHeight = parseFloat(piece.dataset.height);
 
         for (const neighbor of window.pieces) {
-            if (neighbor.dataset.groupId === groupId) continue;
+            if (parseInt(neighbor.dataset.groupId) === groupId) continue;
 
             const expectedDx = parseFloat(neighbor.dataset.correctX) - pieceCorrectX;
             const expectedDy = parseFloat(neighbor.dataset.correctY) - pieceCorrectY;


### PR DESCRIPTION
## Summary
- Prevent Connect.wav from playing when moving pieces within the same group by comparing group IDs numerically

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1de550e08320ad5f60cbe52b4cca