### PR TITLE
Increase SignalR message size limit

### DIFF
--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -9,7 +9,8 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddScoped<ModalService>();
-builder.Services.AddSignalR();
+builder.Services.AddSignalR(o =>
+    o.MaximumReceiveMessageSize = 10 * 1024 * 1024);
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- Allow larger SignalR messages to support large puzzle images

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2db1200483209f06e02339b1eb29