### PR TITLE
Handle errors when broadcasting puzzle changes

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -107,7 +107,12 @@ window.createRoom = async function (imageDataUrl, pieceCount) {
 
 window.setPuzzle = async function (roomCode, imageDataUrl, pieceCount) {
     if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
-        await hubConnection.invoke("SetPuzzle", roomCode, imageDataUrl, pieceCount);
+        try {
+            await hubConnection.invoke("SetPuzzle", roomCode, imageDataUrl, pieceCount);
+        } catch (error) {
+            console.error('Error setting puzzle', error);
+            alert('Failed to set puzzle. Please try again.');
+        }
     }
 };
 


### PR DESCRIPTION
## Summary
- wrap `SetPuzzle` hub invocation in try/catch
- log failures and alert user when broadcasting puzzle changes

## Testing
- `dotnet build PuzzleAM.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bc2db1cfe88320a7845d52b826d379