### PR TITLE
Persist puzzle state across empty rooms

### DIFF
--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -51,6 +51,12 @@ public class PuzzleHub : Hub
         if (Rooms.TryGetValue(roomCode, out var state))
         {
             await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
+            await Clients.Caller.SendAsync("BoardState", new
+            {
+                imageDataUrl = state.ImageDataUrl,
+                pieceCount = state.PieceCount,
+                pieces = state.Pieces.Values
+            });
             return state;
         }
 


### PR DESCRIPTION
## Summary
- send board state to a player joining a room so puzzle piece positions and groups are restored

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc334075cc8320934d301196cc0d48