### PR TITLE
Enhance puzzle settings panel with icons and copy button

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -3,7 +3,8 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
-<div class="d-flex align-items-center gap-2 mb-3">
+<div class="settings-panel d-flex flex-wrap justify-content-center align-items-center gap-2 mb-3">
+    <span class="puzzle-icon">🧩</span>
     <select @bind="selectedPieces" class="form-select w-auto">
         @foreach (var option in PieceOptions)
         {
@@ -11,17 +12,19 @@
         }
     </select>
 
-    <InputFile OnChange="OnInputFileChange" class="btn btn-primary" />
+    <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
+    <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">🖼️</label>
 
-    <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select w-auto">
-        <option value="#EFECE6">#EFECE6</option>
-        <option value="#E7F1DC">#E7F1DC</option>
-        <option value="#C8D2C5">#C8D2C5</option>
+    <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select w-auto color-select" style="background-color:@selectedBackground;">
+        <option value="#EFECE6" style="background-color:#EFECE6;"></option>
+        <option value="#E7F1DC" style="background-color:#E7F1DC;"></option>
+        <option value="#C8D2C5" style="background-color:#C8D2C5;"></option>
     </select>
 
     @if (!string.IsNullOrEmpty(RoomCode))
     {
         <span>Room Code: @RoomCode</span>
+        <button class="btn btn-outline-secondary" @onclick="CopyRoomCode">Copy</button>
         <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
     }
 </div>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -76,6 +76,21 @@ public partial class PuzzleGame : ComponentBase
         }
     }
 
+    private async Task CopyRoomCode()
+    {
+        if (!string.IsNullOrEmpty(RoomCode))
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("navigator.clipboard.writeText", RoomCode);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error copying room code");
+            }
+        }
+    }
+
     private async Task LeaveRoom()
     {
         if (joined)

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -99,3 +99,28 @@ h1:focus {
     cursor: grab;
     z-index: 1;
 }
+
+.settings-panel {
+    background-color: #ffffff;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.load-icon {
+    cursor: pointer;
+    font-size: 1.25rem;
+}
+
+.color-select {
+    width: 3rem;
+    padding: 0.2rem;
+}
+
+.color-select option {
+    color: transparent;
+}
+
+.puzzle-icon {
+    font-size: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- Replace image upload button with icon and color-coded background selector
- Add puzzle piece icon, copyable room code, and style settings panel

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc35b4417c8320939e68d9bfc9dff0