### PR TITLE
Improve settings panel usability

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -3,30 +3,38 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
-<div class="settings-panel d-flex flex-wrap justify-content-center align-items-center gap-2 mb-3">
-    <span class="puzzle-icon">🧩</span>
-    <select @bind="selectedPieces" class="form-select w-auto">
-        @foreach (var option in PieceOptions)
-        {
-            <option value="@option">@option</option>
-        }
-    </select>
-
-    <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
-    <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">🖼️</label>
-
-    <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select w-auto color-select" style="background-color:@selectedBackground;">
-        <option value="#EFECE6" style="background-color:#EFECE6;"></option>
-        <option value="#E7F1DC" style="background-color:#E7F1DC;"></option>
-        <option value="#C8D2C5" style="background-color:#C8D2C5;"></option>
-    </select>
-
-    @if (!string.IsNullOrEmpty(RoomCode))
+<div class="d-inline-flex align-items-center mb-3">
+    @if (settingsVisible)
     {
-        <span>Room Code: @RoomCode</span>
-        <button class="btn btn-outline-secondary" @onclick="CopyRoomCode">Copy</button>
-        <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
+        <div class="settings-panel d-inline-flex flex-wrap justify-content-center align-items-center gap-2">
+            <span class="puzzle-icon">🧩</span>
+            <select @bind="selectedPieces" class="form-select w-auto">
+                @foreach (var option in PieceOptions)
+                {
+                    <option value="@option">@option</option>
+                }
+            </select>
+
+            <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
+            <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">🖼️</label>
+
+            <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select color-select" style="background-color:@selectedBackground;">
+                <option value="#EFECE6" style="background-color:#EFECE6;" selected></option>
+                <option value="#E7F1DC" style="background-color:#E7F1DC;"></option>
+                <option value="#C8D2C5" style="background-color:#C8D2C5;"></option>
+            </select>
+
+            @if (!string.IsNullOrEmpty(RoomCode))
+            {
+                <span>Room Code: @RoomCode</span>
+                <button class="btn btn-outline-secondary copy-icon" @onclick="CopyRoomCode" title="Copy">📋</button>
+                <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
+            }
+        </div>
     }
+    <button class="btn btn-outline-secondary toggle-tab ms-2" @onclick="ToggleSettings">
+        @(settingsVisible ? "❮" : "❯")
+    </button>
 </div>
 
 <div id="puzzleContainer"></div>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -18,6 +18,7 @@ public partial class PuzzleGame : ComponentBase
     private string selectedBackground = "#EFECE6";
     private bool scriptLoaded;
     private bool joined;
+    private bool settingsVisible = true;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -107,5 +108,10 @@ public partial class PuzzleGame : ComponentBase
             joined = false;
             Nav.NavigateTo("/");
         }
+    }
+
+    private void ToggleSettings()
+    {
+        settingsVisible = !settingsVisible;
     }
 }

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -113,7 +113,7 @@ h1:focus {
 }
 
 .color-select {
-    width: 3rem;
+    width: 4rem;
     padding: 0.2rem;
 }
 
@@ -122,5 +122,14 @@ h1:focus {
 }
 
 .puzzle-icon {
+    font-size: 1.25rem;
+}
+
+.copy-icon {
+    font-size: 1.25rem;
+}
+
+.toggle-tab {
+    cursor: pointer;
     font-size: 1.25rem;
 }


### PR DESCRIPTION
## Summary
- Make settings panel size fit its contents and add show/hide tab
- Default background color to first option and display color in selector
- Use a clipboard icon for copying room code

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc37cc988c8320bb2610822a43b3f7