### PR TITLE
Broadcast MovePiece events to all group members

### DIFF
--- a/PuzzleAM/Hubs/PuzzleHub.cs
+++ b/PuzzleAM/Hubs/PuzzleHub.cs
@@ -155,7 +155,7 @@ public class PuzzleHub : Hub
         if (Rooms.TryGetValue(roomCode, out var state))
         {
             state.Pieces[piece.Id] = piece;
-            await Clients.OthersInGroup(roomCode).SendAsync("PieceMoved", piece);
+            await Clients.Group(roomCode).SendAsync("PieceMoved", piece);
         }
     }
 }


### PR DESCRIPTION
## Summary
- broadcast `MovePiece` updates to entire SignalR group so the caller stays in sync
- track locally moved pieces on the client and ignore redundant server updates during drags

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc69ab81d8832092da10b86936d49e