### PR TITLE
Improve mobile responsiveness for puzzle app

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -133,3 +133,20 @@ h1:focus {
     cursor: pointer;
     font-size: 1.25rem;
 }
+
+@media (max-width: 768px) {
+    .settings-panel {
+        flex-direction: column;
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .settings-panel > * {
+        width: 100%;
+        margin-bottom: 0.5rem;
+    }
+
+    .settings-panel > *:last-child {
+        margin-bottom: 0;
+    }
+}

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -172,8 +172,10 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         const availableWidth = window.innerWidth - containerRect.left;
         const availableHeight = window.innerHeight - containerRect.top;
 
-        const targetWidth = availableWidth * 0.5;
-        const targetHeight = availableHeight * 0.5;
+        const widthFactor = window.innerWidth <= 768 ? 0.9 : 0.5;
+        const heightFactor = window.innerWidth <= 768 ? 0.6 : 0.5;
+        const targetWidth = availableWidth * widthFactor;
+        const targetHeight = availableHeight * heightFactor;
         const pieceSize = Math.min(targetWidth / cols, targetHeight / rows);
         const scaledWidth = pieceSize * cols;
         const scaledHeight = pieceSize * rows;


### PR DESCRIPTION
## Summary
- Adjust puzzle board sizing logic to scale better on narrow viewports
- Stack puzzle settings vertically on small screens for better usability

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70498ed083209dba073e908a7ea7