### PR TITLE
Add collapsible navigation and animated settings panel

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -1,20 +1,26 @@
 ﻿@inherits LayoutComponentBase
 
 <div class="page">
+    <input type="checkbox" id="nav-toggle" class="nav-toggle" checked />
     <div class="sidebar">
         <NavMenu />
     </div>
+    <label for="nav-toggle" class="nav-tab"></label>
 
     <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
-
         <article class="content px-4">
             @Body
         </article>
     </main>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        if (window.innerWidth < 992) {
+            document.getElementById('nav-toggle').checked = false;
+        }
+    });
+</script>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -8,41 +8,54 @@ main {
     flex: 1;
 }
 
+
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+    overflow: hidden;
+    transition: width 0.3s ease;
+    width: 250px;
 }
 
-.top-row {
-    background-color: #f7f7f7;
-    border-bottom: 1px solid #d6d5d5;
-    justify-content: flex-end;
-    height: 3.5rem;
+.nav-toggle {
+    display: none;
+}
+
+.nav-tab {
+    position: absolute;
+    top: 1rem;
+    left: 250px;
+    width: 1.5rem;
+    height: 1.5rem;
+    background-color: rgba(5, 39, 103, 0.8);
+    color: white;
+    border-radius: 0 4px 4px 0;
+    cursor: pointer;
     display: flex;
     align-items: center;
+    justify-content: center;
+    transition: left 0.3s ease;
+    z-index: 1;
 }
 
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        white-space: nowrap;
-        margin-left: 1.5rem;
-        text-decoration: none;
-    }
+.nav-tab::after {
+    content: '\25C0';
+}
 
-    .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
-        text-decoration: underline;
-    }
+.nav-toggle:not(:checked) ~ .sidebar {
+    width: 0;
+}
 
-    .top-row ::deep a:first-child {
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+.nav-toggle:not(:checked) ~ .nav-tab {
+    left: 0;
+}
+
+.nav-toggle:not(:checked) ~ .nav-tab::after {
+    content: '\25B6';
+}
 
 @media (max-width: 640.98px) {
-    .top-row {
-        justify-content: space-between;
-    }
-
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        margin-left: 0;
+    .nav-tab {
+        top: 0.5rem;
     }
 }
 
@@ -58,19 +71,7 @@ main {
         top: 0;
     }
 
-    .top-row {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-    }
-
-    .top-row.auth ::deep a:first-child {
-        flex: 1;
-        text-align: right;
-        width: 0;
-    }
-
-    .top-row, article {
+    article {
         padding-left: 2rem !important;
         padding-right: 1.5rem !important;
     }

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -3,37 +3,34 @@
 
 <PageTitle>Puzzle Game</PageTitle>
 
-<div class="d-inline-flex align-items-center mb-3">
-    @if (settingsVisible)
-    {
-        <div class="settings-panel d-inline-flex flex-wrap justify-content-center align-items-center gap-2">
-            <span class="puzzle-icon">🧩</span>
-            <select @bind="selectedPieces" class="form-select w-auto">
-                @foreach (var option in PieceOptions)
-                {
-                    <option value="@option">@option</option>
-                }
-            </select>
-
-            <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
-            <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">🖼️</label>
-
-            <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select color-select" style="background-color:@selectedBackground;">
-                <option value="#EFECE6" style="background-color:#EFECE6;" selected></option>
-                <option value="#E7F1DC" style="background-color:#E7F1DC;"></option>
-                <option value="#C8D2C5" style="background-color:#C8D2C5;"></option>
-            </select>
-
-            @if (!string.IsNullOrEmpty(RoomCode))
+<div class="settings-wrapper mb-3">
+    <div class="settings-panel @(settingsVisible ? "open" : "closed") d-flex flex-wrap justify-content-center align-items-center gap-2">
+        <span class="puzzle-icon">🧩</span>
+        <select @bind="selectedPieces" class="form-select w-auto">
+            @foreach (var option in PieceOptions)
             {
-                <span>Room Code: @RoomCode</span>
-                <button class="btn btn-outline-secondary copy-icon" @onclick="CopyRoomCode" title="Copy">📋</button>
-                <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
+                <option value="@option">@option</option>
             }
-        </div>
-    }
-    <button class="btn btn-outline-secondary toggle-tab ms-2" @onclick="ToggleSettings">
-        @(settingsVisible ? "❮" : "❯")
+        </select>
+
+        <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
+        <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">🖼️</label>
+
+        <select @bind="selectedBackground" @bind:after="OnBackgroundChange" class="form-select color-select" style="background-color:@selectedBackground;">
+            <option value="#EFECE6" style="background-color:#EFECE6;" selected></option>
+            <option value="#E7F1DC" style="background-color:#E7F1DC;"></option>
+            <option value="#C8D2C5" style="background-color:#C8D2C5;"></option>
+        </select>
+
+        @if (!string.IsNullOrEmpty(RoomCode))
+        {
+            <span>Room Code: @RoomCode</span>
+            <button class="btn btn-outline-secondary copy-icon" @onclick="CopyRoomCode" title="Copy">📋</button>
+            <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
+        }
+    </div>
+    <button class="btn btn-outline-secondary settings-toggle" @onclick="ToggleSettings">
+        @(settingsVisible ? "▲" : "▼")
     </button>
 </div>
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -1,0 +1,21 @@
+.settings-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.settings-panel {
+    overflow: hidden;
+    transition: max-height 0.3s ease, opacity 0.3s ease;
+    max-height: 500px;
+    opacity: 1;
+}
+
+.settings-panel.closed {
+    max-height: 0;
+    opacity: 0;
+}
+
+.settings-toggle {
+    margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Allow collapsing the sidebar via a tab and default it closed on smaller screens
- Center puzzle settings panel with up-slide hide behavior
- Remove unused top about panel

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7916a1ac8320a63fe9e505f3d1c4