### PR TITLE
Refresh neighbor shadows on remote moves

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -65,6 +65,19 @@ function startHubConnection() {
                 piece.dataset.groupId = data.groupId;
             }
             updatePieceShadow(piece);
+
+            const row = parseInt(piece.dataset.row);
+            const col = parseInt(piece.dataset.col);
+
+            const topNeighbor = row > 0 ? window.pieces[(row - 1) * window.puzzleCols + col] : null;
+            if (topNeighbor) {
+                updatePieceShadow(topNeighbor);
+            }
+
+            const leftNeighbor = col > 0 ? window.pieces[row * window.puzzleCols + (col - 1)] : null;
+            if (leftNeighbor) {
+                updatePieceShadow(leftNeighbor);
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- ensure top and left neighbors update their shadows when a piece moves remotely

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bfb205083208cc587ed7dfcf862