### PR TITLE
Allow puzzle shadows to extend outside container

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -1,6 +1,9 @@
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     height: 100%;
+    /* Hide any overflow to prevent unwanted scrollbars while allowing
+       inner containers to show their shadows outside their bounds */
+    overflow: hidden;
 }
 
 body {
@@ -83,9 +86,8 @@ h1:focus {
 .puzzle-container {
     position: relative;
     background-color: transparent;
-    /* Prevent puzzle pieces or their shadows from overflowing and causing
-       scrollbars so the entire page fits within the viewport */
-    overflow: hidden;
+    /* Allow puzzle piece shadows to be visible outside the container */
+    overflow: visible;
 }
 
 .puzzle-board {


### PR DESCRIPTION
## Summary
- show puzzle piece shadows by switching `.puzzle-container` overflow to `visible`
- suppress global scrollbars by hiding overflow on the `html, body` elements

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bfba7d483208bacf1b472c8bc26