### PR TITLE
Handle shadows for all puzzle piece edges

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -368,6 +368,16 @@ function updatePieceShadow(piece) {
 
     const shadows = [];
 
+    const topNeighbor = row > 0 ? window.pieces[(row - 1) * window.puzzleCols + col] : null;
+    if (!(topNeighbor && parseInt(topNeighbor.dataset.groupId) === groupId)) {
+        shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
+    }
+
+    const leftNeighbor = col > 0 ? window.pieces[row * window.puzzleCols + (col - 1)] : null;
+    if (!(leftNeighbor && parseInt(leftNeighbor.dataset.groupId) === groupId)) {
+        shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
+    }
+
     const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
     if (!(bottomNeighbor && parseInt(bottomNeighbor.dataset.groupId) === groupId)) {
         shadows.push('drop-shadow(0 3px 6px rgba(0, 0, 0, 0.5))');


### PR DESCRIPTION
## Summary
- Add top and left neighbor checks when updating puzzle piece shadows
- Always compute shadows for all four sides before applying the filter

## Testing
- `node - <<'NODE' ...` (simulate updatePieceShadow for center piece)
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc907755f08320aaf49129457294a7