### PR TITLE
Sync neighboring piece shadows on remote moves

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -78,6 +78,16 @@ function startHubConnection() {
             if (leftNeighbor) {
                 updatePieceShadow(leftNeighbor);
             }
+
+            const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
+            if (bottomNeighbor) {
+                updatePieceShadow(bottomNeighbor);
+            }
+
+            const rightNeighbor = col < window.puzzleCols - 1 ? window.pieces[row * window.puzzleCols + (col + 1)] : null;
+            if (rightNeighbor) {
+                updatePieceShadow(rightNeighbor);
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- Update PieceMoved handler to refresh bottom and right neighbor shadows when a piece moves

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92b5d79c8320936b8b662f23ca43