### PR TITLE
Add Bootstrap bundle script reference

### DIFF
--- a/PuzzleAM/Components/App.razor
+++ b/PuzzleAM/Components/App.razor
@@ -17,6 +17,7 @@
     <Routes />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js"></script>
     <script src="puzzle.js"></script>
+    <script src="@Assets["lib/bootstrap/dist/js/bootstrap.bundle.min.js"]"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- load Bootstrap's bundled JavaScript in App.razor so Bootstrap components work

## Testing
- `dotnet build`
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc769a8e48320a0955ba66ed01361