### PR TITLE
Show username and close auth modals on login/register

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -9,9 +9,16 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using System.Net.Http.Json
 
-<div class="position-absolute top-0 end-0 p-3">
+<div class="position-absolute top-0 end-0 p-3 d-flex align-items-center">
+    @if (!string.IsNullOrEmpty(currentUsername))
+    {
+        <span class="me-2">@currentUsername</span>
+    }
     <button class="btn btn-outline-primary me-2" data-bs-toggle="modal" data-bs-target="#registerModal">Create Account</button>
-    <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#loginModal">Login</button>
+    @if (string.IsNullOrEmpty(currentUsername))
+    {
+        <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#loginModal">Login</button>
+    }
 </div>
 
 <h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
@@ -44,6 +51,10 @@
                 @if (!string.IsNullOrEmpty(registerError))
                 {
                     <div class="text-danger mt-2">@registerError</div>
+                }
+                @if (!string.IsNullOrEmpty(registerMessage))
+                {
+                    <div class="text-success mt-2">@registerMessage</div>
                 }
             </div>
             <div class="modal-footer">
@@ -81,7 +92,20 @@
     private RegisterModel registerModel = new();
     private LoginModel loginModel = new();
     private string? registerError;
+    private string? registerMessage;
     private string? loginError;
+    private string? currentUsername;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            currentUsername = await Http.GetStringAsync("/user");
+        }
+        catch
+        {
+        }
+    }
 
     private async Task CreateRoom()
     {
@@ -120,10 +144,13 @@
         if (response.IsSuccessStatusCode)
         {
             registerError = null;
+            registerMessage = "Account created successfully";
+            currentUsername = registerModel.Username;
         }
         else
         {
             registerError = "Registration failed";
+            registerMessage = null;
         }
     }
 
@@ -139,6 +166,8 @@
         if (response.IsSuccessStatusCode)
         {
             loginError = null;
+            currentUsername = loginModel.Username;
+            await JS.InvokeVoidAsync("closeModal", "loginModal");
         }
         else
         {

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -7,6 +7,7 @@ using PuzzleAM.Hubs;
 using PuzzleAM.ViewServices;
 using Microsoft.AspNetCore.Components;
 using System.Net.Http;
+using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -81,6 +82,11 @@ app.MapPost("/login", async (SignInManager<IdentityUser> signInManager, LoginReq
     var result = await signInManager.PasswordSignInAsync(req.Username, req.Password, isPersistent: false, lockoutOnFailure: false);
     return result.Succeeded ? Results.Ok() : Results.BadRequest("Invalid login attempt");
 });
+
+app.MapGet("/user", (ClaimsPrincipal user) =>
+    user.Identity?.IsAuthenticated == true
+        ? Results.Ok(user.Identity.Name)
+        : Results.Unauthorized());
 
 app.Run();
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -543,3 +543,12 @@ function checkCompletion() {
         playApplauseSound();
     }
 }
+
+window.closeModal = function (id) {
+    const el = document.getElementById(id);
+    if (!el) {
+        return;
+    }
+    const modal = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
+    modal.hide();
+};


### PR DESCRIPTION
## Summary
- Display logged-in username beside Create Account button and hide login button
- Show account creation success message, auto-sign in, and close login modal on success
- Add endpoint and JS helper to fetch user name and close Bootstrap modals

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd71e452483208949b5e35a956af9