### PR TITLE
Use authenticated name when creating room and fix password tooltip formatting

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -45,7 +45,7 @@
                 <InputText @bind-Value="registerModel.Username" class="form-control" placeholder="Username" />
                 <div class="input-group mt-2">
                     <InputText @bind-Value="registerModel.Password" type="password" class="form-control" placeholder="Password" />
-                    <span class="input-group-text" title="Password requirements:\n- At least 6 characters\n- At least one digit\n- At least one lowercase letter\n- At least one uppercase letter\n- At least one non-alphanumeric character\n- At least one unique character">&#9432;</span>
+                    <span class="input-group-text" data-bs-toggle="tooltip" data-bs-html="true" title="Password requirements:<br>- At least 6 characters<br>- At least one digit<br>- At least one lowercase letter<br>- At least one uppercase letter<br>- At least one non-alphanumeric character<br>- At least one unique character">&#9432;</span>
                 </div>
                 <InputText @bind-Value="registerModel.ConfirmPassword" type="password" class="form-control mt-2" placeholder="Confirm Password" />
                 @if (!string.IsNullOrEmpty(registerError))
@@ -107,6 +107,14 @@
         }
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("initTooltips");
+        }
+    }
+
     private async Task CreateRoom()
     {
         var code = await JS.InvokeAsync<string>("createRoom");
@@ -146,6 +154,7 @@
             registerError = null;
             registerMessage = "Account created successfully";
             currentUsername = registerModel.Username;
+            await JS.InvokeVoidAsync("restartHubConnection");
         }
         else
         {
@@ -168,6 +177,7 @@
             loginError = null;
             currentUsername = loginModel.Username;
             await JS.InvokeVoidAsync("closeModal", "loginModal");
+            await JS.InvokeVoidAsync("restartHubConnection");
         }
         else
         {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -44,7 +44,7 @@ function playApplauseSound() {
     }
 }
 
-function startHubConnection() {
+async function startHubConnection() {
     hubConnection = new signalR.HubConnectionBuilder()
         .withUrl("/puzzlehub")
         .withAutomaticReconnect()
@@ -98,7 +98,11 @@ function startHubConnection() {
         }
     });
 
-    hubConnection.start().catch(err => console.error(err));
+    try {
+        await hubConnection.start();
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 function sendMove(piece) {
@@ -551,4 +555,20 @@ window.closeModal = function (id) {
     }
     const modal = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
     modal.hide();
+};
+
+window.restartHubConnection = async function () {
+    if (hubConnection) {
+        try {
+            await hubConnection.stop();
+        } catch (e) {
+            console.error(e);
+        }
+    }
+    await startHubConnection();
+};
+
+window.initTooltips = function () {
+    const triggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    triggerList.map(el => new bootstrap.Tooltip(el));
 };


### PR DESCRIPTION
## Summary
- restart SignalR connection after login or registration so authenticated users appear with their username in rooms
- improve password policy overlay using Bootstrap tooltip with HTML formatting
- expose utilities to restart hub connection and initialize tooltips

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdac6ec38832099336ecfeaf9005b