### PR TITLE
Ensure user appears in participant list after room join

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -36,12 +36,15 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
                 if (!joined && !string.IsNullOrEmpty(RoomCode))
                 {
                     var state = await JS.InvokeAsync<PuzzleState?>("joinRoom", RoomCode);
-                    if (state is not null && !string.IsNullOrEmpty(state.ImageDataUrl))
+                    if (state is not null)
                     {
-                        imageDataUrl = state.ImageDataUrl;
-                        selectedPieces = state.PieceCount;
+                        if (!string.IsNullOrEmpty(state.ImageDataUrl))
+                        {
+                            imageDataUrl = state.ImageDataUrl;
+                            selectedPieces = state.PieceCount;
+                        }
+                        joined = true;
                     }
-                    joined = true;
                 }
             }
             catch (Exception ex)

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -121,7 +121,8 @@ function sendMove(piece) {
     }
 }
 
-window.addEventListener("load", startHubConnection);
+// Start the SignalR connection immediately instead of waiting for the window load event
+startHubConnection();
 
 window.setRoomCode = function (code) {
     currentRoomCode = code;


### PR DESCRIPTION
## Summary
- Start SignalR hub connection immediately so join can update user list
- Only mark room as joined once join succeeds

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdd019b808320b31880b912757eb3