### PR TITLE
Use JS fetch for auth

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -7,7 +7,6 @@
 @inject HttpClient Http
 @inject AntiforgeryStateProvider Antiforgery
 @using Microsoft.AspNetCore.Components.Forms
-@using System.Net.Http.Json
 
 <div class="position-absolute top-0 end-0 p-3 d-flex align-items-center">
     @if (!string.IsNullOrEmpty(currentUsername))
@@ -143,13 +142,8 @@
             return;
         }
         var token = Antiforgery.GetAntiforgeryToken();
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/register")
-        {
-            Content = JsonContent.Create(registerModel)
-        };
-        request.Headers.Add("RequestVerificationToken", token.Value);
-        var response = await Http.SendAsync(request);
-        if (response.IsSuccessStatusCode)
+        var success = await JS.InvokeAsync<bool>("register", token.Value, registerModel);
+        if (success)
         {
             registerError = null;
             registerMessage = "Account created successfully";
@@ -166,13 +160,8 @@
     private async Task Login()
     {
         var token = Antiforgery.GetAntiforgeryToken();
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/login")
-        {
-            Content = JsonContent.Create(loginModel)
-        };
-        request.Headers.Add("RequestVerificationToken", token.Value);
-        var response = await Http.SendAsync(request);
-        if (response.IsSuccessStatusCode)
+        var success = await JS.InvokeAsync<bool>("login", token.Value, loginModel);
+        if (success)
         {
             loginError = null;
             currentUsername = loginModel.Username;

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -558,6 +558,32 @@ window.closeModal = function (id) {
     modal.hide();
 };
 
+window.register = async function (token, model) {
+    const response = await fetch('/register', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'RequestVerificationToken': token
+        },
+        body: JSON.stringify(model),
+        credentials: 'include'
+    });
+    return response.ok;
+};
+
+window.login = async function (token, model) {
+    const response = await fetch('/login', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'RequestVerificationToken': token
+        },
+        body: JSON.stringify(model),
+        credentials: 'include'
+    });
+    return response.ok;
+};
+
 window.restartHubConnection = async function () {
     if (hubConnection) {
         try {


### PR DESCRIPTION
## Summary
- Call browser-side fetch via JS interop for Register and Login instead of HttpClient
- Add JS `register`/`login` helpers using fetch with anti-forgery token and cookies

## Testing
- `dotnet test` *(no tests found)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bd5f7ec49883208ad2576d9450107c