### PR TITLE
Keep user logged in when returning from puzzle room

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -2,9 +2,9 @@
 @rendermode InteractiveServer
 @using PuzzleAM.Model
 @using Microsoft.AspNetCore.Antiforgery
+@using Microsoft.AspNetCore.Components.Authorization
 @inject IJSRuntime JS
 @inject NavigationManager Nav
-@inject HttpClient Http
 @inject AntiforgeryStateProvider Antiforgery
 @using Microsoft.AspNetCore.Components.Forms
 
@@ -94,15 +94,16 @@
     private string? registerMessage;
     private string? loginError;
     private string? currentUsername;
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
-        try
+        var authState = await AuthenticationStateTask;
+        var user = authState.User;
+        if (user.Identity?.IsAuthenticated == true)
         {
-            currentUsername = await Http.GetStringAsync("/user");
-        }
-        catch
-        {
+            currentUsername = user.Identity.Name;
         }
     }
 

--- a/PuzzleAM/Components/Routes.razor
+++ b/PuzzleAM/Components/Routes.razor
@@ -1,6 +1,8 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
-    </Found>
-</Router>
+<CascadingAuthenticationState>
+    <Router AppAssembly="typeof(Program).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+    </Router>
+</CascadingAuthenticationState>


### PR DESCRIPTION
## Summary
- Read authentication state directly in Home page to determine signed-in user
- Wrap router in CascadingAuthenticationState so components can access auth state

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd61d773348320a35403e78a7c868a