### PR TITLE
Replace login button with sign-out option

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -18,6 +18,10 @@
     {
         <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#loginModal">Login</button>
     }
+    else
+    {
+        <button class="btn btn-outline-secondary" @onclick="Logout">Sign out</button>
+    }
 </div>
 
 <h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
@@ -172,6 +176,17 @@
         else
         {
             loginError = "Login failed";
+        }
+    }
+
+    private async Task Logout()
+    {
+        var token = Antiforgery.GetAntiforgeryToken();
+        var success = await JS.InvokeAsync<bool>("logout", token.Value);
+        if (success)
+        {
+            currentUsername = null;
+            await JS.InvokeVoidAsync("restartHubConnection");
         }
     }
 

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -83,6 +83,12 @@ app.MapPost("/login", async (SignInManager<IdentityUser> signInManager, LoginReq
     return result.Succeeded ? Results.Ok() : Results.BadRequest("Invalid login attempt");
 });
 
+app.MapPost("/logout", async (SignInManager<IdentityUser> signInManager) =>
+{
+    await signInManager.SignOutAsync();
+    return Results.Ok();
+});
+
 app.MapGet("/user", (ClaimsPrincipal user) =>
     user.Identity?.IsAuthenticated == true
         ? Results.Ok(user.Identity.Name)

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -584,6 +584,17 @@ window.login = async function (token, model) {
     return response.ok;
 };
 
+window.logout = async function (token) {
+    const response = await fetch('/logout', {
+        method: 'POST',
+        headers: {
+            'RequestVerificationToken': token
+        },
+        credentials: 'include'
+    });
+    return response.ok;
+};
+
 window.restartHubConnection = async function () {
     if (hubConnection) {
         try {


### PR DESCRIPTION
## Summary
- show "Sign out" once a user is logged in and wire it to a logout handler
- add server endpoint and JS helper for signing out

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd65b1fba483209ca6e4bb2280a7bc