### PR TITLE
Handle missing authentication state on Home page

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -98,12 +98,12 @@
     private string? registerMessage;
     private string? loginError;
     private string? currentUsername;
-    [CascadingParameter]
-    private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
+    [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
-        var authState = await AuthenticationStateTask;
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         var user = authState.User;
         if (user.Identity?.IsAuthenticated == true)
         {


### PR DESCRIPTION
## Summary
- Avoid null AuthenticationStateTask by injecting AuthenticationStateProvider
- Populate current user using GetAuthenticationStateAsync

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd679fe0988320ad749d131a59672a