### PR TITLE
Refresh auth state after login/logout to persist sessions

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -153,7 +153,7 @@
             registerError = null;
             registerMessage = "Account created successfully";
             currentUsername = registerModel.Username;
-            await JS.InvokeVoidAsync("restartHubConnection");
+            Nav.NavigateTo("/", true);
         }
         else
         {
@@ -170,8 +170,7 @@
         {
             loginError = null;
             currentUsername = loginModel.Username;
-            await JS.InvokeVoidAsync("closeModal", "loginModal");
-            await JS.InvokeVoidAsync("restartHubConnection");
+            Nav.NavigateTo("/", true);
         }
         else
         {
@@ -186,7 +185,7 @@
         if (success)
         {
             currentUsername = null;
-            await JS.InvokeVoidAsync("restartHubConnection");
+            Nav.NavigateTo("/", true);
         }
     }
 


### PR DESCRIPTION
## Summary
- Reload home page after register, login or logout so the Blazor circuit picks up new authentication state

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cc344488320862928d55d13074f