### PR TITLE
Ensure snapped piece positions use integer pixels

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -109,10 +109,12 @@ async function startHubConnection() {
 function sendMove(piece) {
     if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected &&
         typeof window.boardLeft === 'number' && typeof window.boardWidth === 'number') {
+        const left = Math.round(parseFloat(piece.style.left));
+        const top = Math.round(parseFloat(piece.style.top));
         const payload = {
             id: parseInt(piece.dataset.pieceId),
-            left: (parseFloat(piece.style.left) - window.boardLeft) / window.boardWidth,
-            top: (parseFloat(piece.style.top) - window.boardTop) / window.boardHeight
+            left: (left - window.boardLeft) / window.boardWidth,
+            top: (top - window.boardTop) / window.boardHeight
         };
         const groupId = parseInt(piece.dataset.groupId);
         if (Number.isFinite(groupId)) {
@@ -512,8 +514,10 @@ function snapPiece(el) {
 
                 if (Math.abs(diffX) < threshold && Math.abs(diffY) < threshold) {
                     groupPieces.forEach(p => {
-                        p.style.left = (parseFloat(p.style.left) + diffX) + 'px';
-                        p.style.top = (parseFloat(p.style.top) + diffY) + 'px';
+                        const newLeft = Math.round(parseFloat(p.style.left) + diffX);
+                        const newTop = Math.round(parseFloat(p.style.top) + diffY);
+                        p.style.left = newLeft + 'px';
+                        p.style.top = newTop + 'px';
                         sendMove(p);
                     });
 


### PR DESCRIPTION
## Summary
- Round snapped piece positions to integer pixel values
- Send rounded positions to server in `sendMove`

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7d89dfe08320b5b56b86860841cd