### PR TITLE
Disable image smoothing for puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -274,8 +274,10 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
                 piece.dataset.col = x;
 
                 const ctx = piece.getContext('2d');
+                ctx.imageSmoothingEnabled = false;
                 ctx.clearRect(0, 0, piece.width, piece.height);
                 ctx.save();
+                ctx.translate(0.5, 0.5);
                 drawPiecePath(ctx, pieceWidth, pieceHeight, top, right, bottom, left, offset);
                 ctx.clip();
                 ctx.drawImage(


### PR DESCRIPTION
## Summary
- disable canvas image smoothing when rendering puzzle pieces
- align piece rendering to pixel grid to reduce seams

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7d8a8e848320a90e1d309af9a661