### PR TITLE
Update neighbor shadow clearing on piece move

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -84,6 +84,16 @@ async function startHubConnection() {
             if (leftNeighbor) {
                 updatePieceShadow(leftNeighbor);
             }
+
+            const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
+            if (bottomNeighbor) {
+                updatePieceShadow(bottomNeighbor);
+            }
+
+            const rightNeighbor = col < window.puzzleCols - 1 ? window.pieces[row * window.puzzleCols + (col + 1)] : null;
+            if (rightNeighbor) {
+                updatePieceShadow(rightNeighbor);
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- Update `PieceMoved` SignalR handler to refresh bottom and right neighbor shadows

## Testing
- `node - <<'NODE' ... NODE`
- `dotnet test` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81a07f04832098cc39cfd670b8b9