### PR TITLE
Scale piece shadow threshold with piece size

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -395,7 +395,7 @@ function updatePieceShadow(piece) {
     const pieceHeight = parseFloat(piece.dataset.height);
 
     const shadows = [];
-    const threshold = 5;
+    const threshold = Math.min(pieceWidth, pieceHeight) * 0.05;
 
     const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
     if (bottomNeighbor && parseInt(bottomNeighbor.dataset.groupId) === groupId) {


### PR DESCRIPTION
## Summary
- adapt piece shadow detection threshold to a percentage of piece dimensions

## Testing
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `node test` verifying shadow appears only when gap exceeds 5% of piece size


------
https://chatgpt.com/codex/tasks/task_e_68bd81a151308320b4cdff46de11bb75