### PR TITLE
Add puzzle completion timer

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -34,6 +34,8 @@
     </button>
 </div>
 
+<div class="timer-display">Time: @elapsed.ToString(@"hh\\:mm\\:ss")</div>
+
 <div id="puzzleContainer"></div>
 
 <div class="user-panel">

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -32,3 +32,9 @@
     max-height: 90vh;
     overflow-y: auto;
 }
+
+.timer-display {
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+    text-align: center;
+}

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -18,6 +18,11 @@ window.registerUserListHandler = function (dotNetHelper) {
     userListHandler = dotNetHelper;
 };
 
+let puzzleEventHandler;
+window.registerPuzzleEventHandler = function (dotNetHelper) {
+    puzzleEventHandler = dotNetHelper;
+};
+
 function playStartSound() {
     try {
         sounds.start.currentTime = 0;
@@ -312,6 +317,9 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         }
         updateAllShadows();
         playStartSound();
+        if (puzzleEventHandler) {
+            puzzleEventHandler.invokeMethodAsync('PuzzleLoaded');
+        }
     };
     img.src = imageDataUrl;
 };
@@ -590,6 +598,9 @@ function checkCompletion() {
     if (solved) {
         console.log('Puzzle completed!');
         playApplauseSound();
+        if (puzzleEventHandler) {
+            puzzleEventHandler.invokeMethodAsync('PuzzleCompleted');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add timer display to Puzzle Game page
- track puzzle load and completion via JS interop
- style timer display

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 0% [Working])*

------
https://chatgpt.com/codex/tasks/task_e_68bd8422d3208320aa4d003eb13b50e7