### PR TITLE
Add gallery for completed puzzles

### DIFF
--- a/PuzzleAM/ApplicationDbContext.cs
+++ b/PuzzleAM/ApplicationDbContext.cs
@@ -10,4 +10,6 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
         : base(options)
     {
     }
+
+    public DbSet<CompletedPuzzle> CompletedPuzzles { get; set; } = default!;
 }

--- a/PuzzleAM/CompletedPuzzle.cs
+++ b/PuzzleAM/CompletedPuzzle.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace PuzzleAM;
+
+public class CompletedPuzzle
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string? UserName { get; set; }
+    public string ImageDataUrl { get; set; } = string.Empty;
+    public int PieceCount { get; set; }
+    public TimeSpan TimeToComplete { get; set; }
+}

--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -8,6 +8,12 @@
 
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="nav flex-column">
+        <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">Home</NavLink>
+        <AuthorizeView>
+            <Authorized>
+                <NavLink class="nav-link" href="/gallery">Gallery</NavLink>
+            </Authorized>
+        </AuthorizeView>
     </nav>
 </div>
 

--- a/PuzzleAM/Components/Pages/Gallery.razor
+++ b/PuzzleAM/Components/Pages/Gallery.razor
@@ -1,0 +1,55 @@
+@page "/gallery"
+@rendermode InteractiveServer
+@using System.Security.Claims
+@using Microsoft.EntityFrameworkCore
+@inject ApplicationDbContext Db
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+<h1>Gallery</h1>
+
+@if (puzzles is null)
+{
+    <p>Loading...</p>
+}
+else if (!puzzles.Any())
+{
+    <p>No completed puzzles yet.</p>
+}
+else
+{
+    <div class="gallery-container">
+        @foreach (var p in puzzles)
+        {
+            <div class="puzzle-item">
+                <img src="@p.ImageDataUrl" alt="Completed puzzle" />
+                <div>Pieces: @p.PieceCount</div>
+                <div>Time: @p.TimeToComplete.ToString(@"hh\\:mm\\:ss")</div>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private List<CompletedPuzzle>? puzzles;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userId is not null)
+            {
+                puzzles = await Db.CompletedPuzzles
+                    .Where(p => p.UserId == userId)
+                    .OrderByDescending(p => p.Id)
+                    .ToListAsync();
+            }
+            else
+            {
+                puzzles = new List<CompletedPuzzle>();
+            }
+        }
+    }
+}

--- a/PuzzleAM/Components/Pages/Gallery.razor.css
+++ b/PuzzleAM/Components/Pages/Gallery.razor.css
@@ -1,0 +1,16 @@
+.gallery-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.puzzle-item {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
+
+.puzzle-item img {
+    max-width: 200px;
+    height: auto;
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add conditional Gallery link to nav menu for authenticated users
- store completed puzzle metadata per user
- introduce Gallery page to view a user's completed puzzles

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a55c7cc8320bd23c2fe59a79a65