### PR TITLE
Ensure CompletedPuzzles table exists

### DIFF
--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -39,6 +39,15 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     db.Database.EnsureCreated();
+    db.Database.ExecuteSqlRaw(
+        @"CREATE TABLE IF NOT EXISTS CompletedPuzzles (
+            Id INTEGER PRIMARY KEY AUTOINCREMENT,
+            UserId TEXT NOT NULL,
+            UserName TEXT NULL,
+            ImageDataUrl TEXT NOT NULL,
+            PieceCount INTEGER NOT NULL,
+            TimeToComplete TEXT NOT NULL
+        );");
 }
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Summary
- guarantee CompletedPuzzles table is present by creating it at startup if missing

## Testing
- `dotnet build`
- `dotnet run --project PuzzleAM/PuzzleAM.csproj --no-build` (then Ctrl+C)
- `sqlite3 PuzzleAM/app.db ".tables"`

------
https://chatgpt.com/codex/tasks/task_e_68bd8c99f2288320b4dcbc21d03b1da3