### PR TITLE
Fix duplicate puzzle saves and scope gallery by user

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -31,6 +31,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     private readonly Stopwatch stopwatch = new();
     private Timer? timer;
     private TimeSpan elapsed = TimeSpan.Zero;
+    private bool completionRecorded;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -142,6 +143,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     [JSInvokable]
     public Task PuzzleLoaded()
     {
+        completionRecorded = false;
         stopwatch.Restart();
         elapsed = TimeSpan.Zero;
         timer?.Dispose();
@@ -156,6 +158,11 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     [JSInvokable]
     public async Task PuzzleCompleted()
     {
+        if (completionRecorded)
+        {
+            return;
+        }
+        completionRecorded = true;
         timer?.Dispose();
         if (stopwatch.IsRunning)
         {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -5,6 +5,8 @@ window.maxZ = 1;
 let hubConnection;
 let currentRoomCode = null;
 const locallyMovedPieces = new Set();
+// Flag to ensure puzzle completion is only processed once
+window.puzzleCompleted = false;
 
 // Load audio assets for various game events
 const sounds = {
@@ -203,6 +205,7 @@ window.setBackgroundColor = function (color) {
 };
 
 window.createPuzzle = function (imageDataUrl, containerId, layout) {
+    window.puzzleCompleted = false;
     const img = new Image();
     img.onload = function () {
         const rows = layout.rows;
@@ -592,10 +595,11 @@ function snapPiece(el) {
 }
 
 function checkCompletion() {
-    if (window.pieces.length === 0) return;
+    if (window.puzzleCompleted || window.pieces.length === 0) return;
     const groupId = window.pieces[0].dataset.groupId;
     const solved = window.pieces.every(p => p.dataset.groupId === groupId);
     if (solved) {
+        window.puzzleCompleted = true;
         console.log('Puzzle completed!');
         playApplauseSound();
         if (puzzleEventHandler) {


### PR DESCRIPTION
## Summary
- avoid multiple puzzle completion events on client and server
- persist completed puzzles once per game with user association

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd919f159483208ff9a3e187cc6b3a