### PR TITLE
Expand puzzle board for small screens

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -86,6 +86,8 @@ h1:focus {
     /* Prevent puzzle pieces or their shadows from overflowing and causing
        scrollbars so the entire page fits within the viewport */
     overflow: hidden;
+    width: 100vw;
+    height: 100vh;
 }
 
 .puzzle-board {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -222,10 +222,16 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         const availableWidth = window.innerWidth - containerRect.left;
         const availableHeight = window.innerHeight - containerRect.top;
 
-        const widthFactor = window.innerWidth <= 768 ? 0.9 : 0.5;
-        const heightFactor = window.innerWidth <= 768 ? 0.6 : 0.5;
-        const targetWidth = availableWidth * widthFactor;
-        const targetHeight = availableHeight * heightFactor;
+        container.style.width = availableWidth + 'px';
+        container.style.height = availableHeight + 'px';
+
+        const containerWidth = container.clientWidth;
+        const containerHeight = container.clientHeight;
+
+        const widthFactor = window.innerWidth <= 768 ? 0.95 : 0.5;
+        const heightFactor = window.innerWidth <= 768 ? 0.95 : 0.5;
+        const targetWidth = containerWidth * widthFactor;
+        const targetHeight = containerHeight * heightFactor;
         const scale = Math.min(targetWidth / img.width, targetHeight / img.height);
         const scaledWidth = img.width * scale;
         const scaledHeight = img.height * scale;
@@ -238,11 +244,8 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         const srcOffsetX = offset / scale;
         const srcOffsetY = offset / scale;
 
-        container.style.width = availableWidth + 'px';
-        container.style.height = availableHeight + 'px';
-
-        const boardLeft = (availableWidth - scaledWidth) / 2;
-        const boardTop = (availableHeight - scaledHeight) / 2;
+        const boardLeft = (containerWidth - scaledWidth) / 2;
+        const boardTop = (containerHeight - scaledHeight) / 2;
 
         const board = document.createElement('div');
         board.classList.add('puzzle-board');


### PR DESCRIPTION
## Summary
- Grow puzzle board to nearly full viewport on mobile and center based on container size
- Make puzzle container fill the viewport via CSS

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb722d1e083208159f943b3aeca9f