### PR TITLE
Add reusable tab component for collapsible UI panels

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -1,11 +1,11 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+@inject IJSRuntime JS
 
 <div class="page">
-    <input type="checkbox" id="nav-toggle" class="nav-toggle" checked />
-    <div class="sidebar">
+    <div class="sidebar @(navOpen ? string.Empty : "closed")">
         <NavMenu />
     </div>
-    <label for="nav-toggle" class="nav-tab"></label>
+    <Tab Class="nav-tab" IsOpen="navOpen" OnToggle="ToggleNav" style="@NavTabStyle" />
 
     <main>
         <article class="content px-4">
@@ -14,16 +14,32 @@
     </main>
 </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        if (window.innerWidth < 992) {
-            document.getElementById('nav-toggle').checked = false;
-        }
-    });
-</script>
-
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    private bool navOpen = true;
+
+    private string NavTabStyle => $"position:absolute;top:1rem;left:{(navOpen ? "250px" : "0")};transition:left 0.3s ease;z-index:1;";
+
+    private void ToggleNav()
+    {
+        navOpen = !navOpen;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var width = await JS.InvokeAsync<int>("eval", "window.innerWidth");
+            if (width < 992)
+            {
+                navOpen = false;
+                StateHasChanged();
+            }
+        }
+    }
+}

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -8,7 +8,6 @@ main {
     flex: 1;
 }
 
-
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
     overflow: hidden;
@@ -16,47 +15,8 @@ main {
     width: 250px;
 }
 
-.nav-toggle {
-    display: none;
-}
-
-.nav-tab {
-    position: absolute;
-    top: 1rem;
-    left: 250px;
-    width: 1.5rem;
-    height: 1.5rem;
-    background-color: rgba(5, 39, 103, 0.8);
-    color: white;
-    border-radius: 0 4px 4px 0;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: left 0.3s ease;
-    z-index: 1;
-}
-
-.nav-tab::after {
-    content: '\25C0';
-}
-
-.nav-toggle:not(:checked) ~ .sidebar {
+.sidebar.closed {
     width: 0;
-}
-
-.nav-toggle:not(:checked) ~ .nav-tab {
-    left: 0;
-}
-
-.nav-toggle:not(:checked) ~ .nav-tab::after {
-    content: '\25B6';
-}
-
-@media (max-width: 640.98px) {
-    .nav-tab {
-        top: 0.5rem;
-    }
 }
 
 @media (min-width: 641px) {

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -29,9 +29,7 @@
             <button class="btn btn-danger" @onclick="LeaveRoom">Leave Room</button>
         }
     </div>
-    <button class="btn btn-outline-secondary settings-toggle" @onclick="ToggleSettings">
-        @(settingsVisible ? "▲" : "▼")
-    </button>
+    <Tab Class="settings-tab" IsOpen="settingsVisible" OnToggle="ToggleSettings" Vertical="true" />
 </div>
 
 <div class="timer-display">Time: @elapsed.ToString(@"hh\:mm\:ss")</div>
@@ -48,7 +46,5 @@
             }
         </ul>
     </div>
-    <button class="btn btn-outline-secondary user-toggle" @onclick="ToggleUserList">
-        @(userListVisible ? "▲" : "▼")
-    </button>
+    <Tab Class="user-tab" IsOpen="userListVisible" OnToggle="ToggleUserList" Vertical="true" />
 </div>

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -16,8 +16,9 @@
     opacity: 0;
 }
 
-.settings-toggle {
+::deep(.settings-tab) {
     margin-top: 0.5rem;
+    border-radius: 4px 4px 0 0;
 }
 
 .user-wrapper {
@@ -47,8 +48,9 @@
     overflow: hidden;
 }
 
-.user-toggle {
+::deep(.user-tab) {
     margin-top: 0.5rem;
+    border-radius: 4px 4px 0 0;
 }
 
 .timer-display {
@@ -67,7 +69,7 @@
         z-index: 1000;
     }
 
-    .settings-toggle {
+    ::deep(.settings-tab) {
         position: fixed;
         bottom: 1rem;
         right: 1rem;

--- a/PuzzleAM/Components/Shared/Tab.razor
+++ b/PuzzleAM/Components/Shared/Tab.razor
@@ -1,0 +1,25 @@
+<button type="button" class="tab @Class" @onclick="HandleToggle" @attributes="AdditionalAttributes">
+    @(IsOpen ? (Vertical ? "\u25B2" : "\u25C0") : (Vertical ? "\u25BC" : "\u25B6"))
+</button>
+
+@code {
+    [Parameter]
+    public bool IsOpen { get; set; }
+
+    [Parameter]
+    public EventCallback OnToggle { get; set; }
+
+    [Parameter]
+    public bool Vertical { get; set; }
+
+    [Parameter]
+    public string Class { get; set; } = string.Empty;
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private Task HandleToggle()
+    {
+        return OnToggle.HasDelegate ? OnToggle.InvokeAsync(null) : Task.CompletedTask;
+    }
+}

--- a/PuzzleAM/Components/Shared/Tab.razor.css
+++ b/PuzzleAM/Components/Shared/Tab.razor.css
@@ -1,0 +1,13 @@
+.tab {
+    width: 1.5rem;
+    height: 1.5rem;
+    background-color: rgba(5, 39, 103, 0.8);
+    color: white;
+    border: none;
+    border-radius: 0 4px 4px 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}

--- a/PuzzleAM/Components/_Imports.razor
+++ b/PuzzleAM/Components/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,4 +8,5 @@
 @using Microsoft.JSInterop
 @using PuzzleAM
 @using PuzzleAM.Components
+@using PuzzleAM.Components.Shared
 @using Microsoft.AspNetCore.Components.Authorization


### PR DESCRIPTION
## Summary
- create a reusable `Tab` component
- use the tab to toggle the navigation menu, settings panel, and user list
- style settings and user panels to work with the new tab

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcf414bb88320bac25399eda10547