### PR TITLE
Close tabs on mobile devices

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -21,7 +21,7 @@
 </div>
 
 @code {
-    private bool navOpen = true;
+    private bool navOpen = false;
 
     private string NavTabStyle => $"position:absolute;top:1rem;left:{(navOpen ? "250px" : "0")};transition:left 0.3s ease;z-index:1;";
 
@@ -35,9 +35,9 @@
         if (firstRender)
         {
             var width = await JS.InvokeAsync<int>("eval", "window.innerWidth");
-            if (width < 992)
+            if (width >= 992)
             {
-                navOpen = false;
+                navOpen = true;
                 StateHasChanged();
             }
         }

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -25,8 +25,8 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     private string selectedBackground = "#EFECE6";
     private bool scriptLoaded;
     private bool joined;
-    private bool settingsVisible = true;
-    private bool userListVisible = true;
+    private bool settingsVisible = false;
+    private bool userListVisible = false;
     private List<string> users = new();
     private DotNetObjectReference<PuzzleGame>? objRef;
     private readonly Stopwatch stopwatch = new();
@@ -40,6 +40,14 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         {
             try
             {
+                var width = await JS.InvokeAsync<int>("eval", "window.innerWidth");
+                if (width >= 992)
+                {
+                    settingsVisible = true;
+                    userListVisible = true;
+                    StateHasChanged();
+                }
+
                 await JS.InvokeVoidAsync("setBackgroundColor", selectedBackground);
                 objRef = DotNetObjectReference.Create(this);
                 await JS.InvokeVoidAsync("registerUserListHandler", objRef);


### PR DESCRIPTION
## Summary
- Initialize navigation sidebar closed and open only on wider screens.
- Start puzzle settings and user list tabs closed on mobile, opening on desktops.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd3418284832088f60e40c7cf93ed