### PR TITLE
Expand puzzle board to fill screen

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -284,9 +284,8 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
 
         const containerWidth = container.clientWidth;
         const containerHeight = container.clientHeight;
-        const isMobile = isMobileDevice();
-        const widthFactor = isMobile ? 0.95 : 0.5;
-        const heightFactor = isMobile ? 0.95 : 0.5;
+        const widthFactor = 0.95;
+        const heightFactor = 0.95;
         const targetWidth = containerWidth * widthFactor;
         const targetHeight = containerHeight * heightFactor;
         const scale = Math.min(targetWidth / img.width, targetHeight / img.height);


### PR DESCRIPTION
## Summary
- ensure puzzle board scales to nearly the full available viewport regardless of device

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd7b5902c832092171efd7bc5d516