### PR TITLE
Use dynamic viewport sizing for puzzle

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -87,7 +87,7 @@ h1:focus {
        scrollbars so the entire page fits within the viewport */
     overflow: hidden;
     width: 100vw;
-    height: 100vh;
+    height: 100dvh;
 }
 
 .puzzle-board {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -183,6 +183,12 @@ let resizeTimeout;
 window.addEventListener('resize', () => {
     clearTimeout(resizeTimeout);
     resizeTimeout = setTimeout(() => {
+        if (window.currentContainerId) {
+            const container = document.getElementById(window.currentContainerId);
+            if (container) {
+                updateContainerDimensions(container);
+            }
+        }
         if (window.currentImageDataUrl && window.currentLayout && window.currentContainerId) {
             window.createPuzzle(window.currentImageDataUrl, window.currentContainerId, window.currentLayout);
         }
@@ -249,6 +255,11 @@ window.setBackgroundColor = function (color) {
     }
 };
 
+function updateContainerDimensions(container) {
+    container.style.width = window.innerWidth + 'px';
+    container.style.height = (document.documentElement.clientHeight || window.innerHeight) + 'px';
+}
+
 window.createPuzzle = function (imageDataUrl, containerId, layout) {
     window.puzzleCompleted = false;
     window.currentImageDataUrl = imageDataUrl;
@@ -275,12 +286,7 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         container.classList.add('puzzle-container');
         container.innerHTML = '';
 
-        const containerRect = container.getBoundingClientRect();
-        const availableWidth = window.innerWidth - containerRect.left;
-        const availableHeight = window.innerHeight - containerRect.top;
-
-        container.style.width = availableWidth + 'px';
-        container.style.height = availableHeight + 'px';
+        updateContainerDimensions(container);
 
         const containerWidth = container.clientWidth;
         const containerHeight = container.clientHeight;


### PR DESCRIPTION
## Summary
- Resize puzzle container using current `window.innerWidth` and `document.documentElement.clientHeight`
- Apply dynamic viewport CSS (`100dvh`) for the puzzle container
- Recalculate container dimensions on window resize before rebuilding the puzzle

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bddb7b23308320800be919cec648f7