### PR TITLE
Make puzzle canvas fill the entire viewport

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -2,6 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    position: relative;
+    z-index: 1;
 }
 
 .settings-panel {
@@ -28,6 +30,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    z-index: 1;
 }
 
 .user-panel {
@@ -57,6 +60,8 @@
     font-size: 1.25rem;
     margin-bottom: 1rem;
     text-align: center;
+    position: relative;
+    z-index: 1;
 }
 
 @media (max-width: 768px) {

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -81,13 +81,16 @@ h1:focus {
 }
 
 .puzzle-container {
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
     background-color: transparent;
     /* Prevent puzzle pieces or their shadows from overflowing and causing
        scrollbars so the entire page fits within the viewport */
     overflow: hidden;
     width: 100vw;
     height: 100vh;
+    z-index: 0;
 }
 
 .puzzle-board {


### PR DESCRIPTION
## Summary
- Ensure the puzzle container spans the full browser viewport.
- Keep settings, timer, and user panels visible by layering them above the puzzle canvas.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bded545d3083208e9628f306593792