### PR TITLE
Use visual viewport for puzzle sizing

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -88,8 +88,10 @@ h1:focus {
     /* Prevent puzzle pieces or their shadows from overflowing and causing
        scrollbars so the entire page fits within the viewport */
     overflow: hidden;
-    width: 100vw;
-    height: 100vh;
+    width: 100dvw;
+    height: 100dvh;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    box-sizing: border-box;
     z-index: 0;
 }
 

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -180,14 +180,18 @@ startHubConnection();
 
 // Rebuild puzzle on window resize using the stored layout (debounced)
 let resizeTimeout;
-window.addEventListener('resize', () => {
+function handleResize() {
     clearTimeout(resizeTimeout);
     resizeTimeout = setTimeout(() => {
         if (window.currentImageDataUrl && window.currentLayout && window.currentContainerId) {
             window.createPuzzle(window.currentImageDataUrl, window.currentContainerId, window.currentLayout);
         }
     }, 200);
-});
+}
+window.addEventListener('resize', handleResize);
+if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', handleResize);
+}
 
 window.setRoomCode = function (code) {
     currentRoomCode = code;
@@ -275,10 +279,12 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         container.classList.add('puzzle-container');
         container.innerHTML = '';
 
-        // Size the container to fill the viewport
+        // Size the container to fill the viewport using visualViewport if available
+        const viewportWidth = window.visualViewport ? window.visualViewport.width : window.innerWidth;
+        const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
         const containerRect = container.getBoundingClientRect();
-        const availableWidth = window.innerWidth - containerRect.left;
-        const availableHeight = window.innerHeight - containerRect.top;
+        const availableWidth = viewportWidth - containerRect.left;
+        const availableHeight = viewportHeight - containerRect.top;
 
         container.style.width = availableWidth + 'px';
         container.style.height = availableHeight + 'px';


### PR DESCRIPTION
## Summary
- size puzzle container with dynamic viewport units and safe-area padding
- compute puzzle dimensions using `window.visualViewport`
- rebuild puzzle on `visualViewport` resize events

## Testing
- `dotnet test` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfb6631bc832097553c0f8aa6eb9d