### PR TITLE
Handle puzzle recreation on orientation changes

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -178,7 +178,7 @@ function sendMove(piece) {
 // Start the SignalR connection immediately instead of waiting for the window load event
 startHubConnection();
 
-// Rebuild puzzle on window resize using the stored layout (debounced)
+// Rebuild puzzle on viewport changes using the stored layout (debounced)
 let resizeTimeout;
 function handleResize() {
     clearTimeout(resizeTimeout);
@@ -189,6 +189,7 @@ function handleResize() {
     }, 200);
 }
 window.addEventListener('resize', handleResize);
+window.addEventListener('orientationchange', handleResize);
 if (window.visualViewport) {
     window.visualViewport.addEventListener('resize', handleResize);
 }


### PR DESCRIPTION
## Summary
- Rebuild puzzle when viewport orientation or size changes by listening to `orientationchange` and `visualViewport` `resize` events

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfc82e24483208593f0311ed41b17