### PR TITLE
Ensure edge pieces stay within view

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -325,8 +325,14 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         const srcOffsetX = offset / scale;
         const srcOffsetY = offset / scale;
 
-        const boardLeft = (containerWidth - scaledWidth) / 2;
-        const boardTop = (containerHeight - scaledHeight) / 2;
+        let boardLeft = (containerWidth - scaledWidth) / 2;
+        let boardTop = (containerHeight - scaledHeight) / 2;
+
+        // Ensure the full puzzle is visible by keeping the board at least an
+        // offset away from the container edges. This prevents edge pieces from
+        // being clipped when the available space is tight.
+        boardLeft = Math.max(boardLeft, offset);
+        boardTop = Math.max(boardTop, offset);
 
         const board = document.createElement('div');
         board.classList.add('puzzle-board');


### PR DESCRIPTION
## Summary
- Prevent board from being positioned too close to container edges so puzzle pieces remain fully visible

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be006e19e88320aae749dd368731af