### PR TITLE
Add puzzle workspace and coordinate clamping

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -80,7 +80,7 @@ h1:focus {
     text-align: start;
 }
 
-.puzzle-container {
+.puzzle-viewport {
     position: fixed;
     top: 0;
     left: 0;
@@ -93,6 +93,13 @@ h1:focus {
     padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
     box-sizing: border-box;
     z-index: 0;
+}
+
+.puzzle-workspace {
+    position: absolute;
+    overflow: visible;
+    top: 0;
+    left: 0;
 }
 
 .puzzle-board {


### PR DESCRIPTION
## Summary
- Replace fixed `.puzzle-container` with a new `.puzzle-viewport` and nested `.puzzle-workspace` for puzzle pieces
- Compute puzzle layout inside the workspace and adjust move coordinates for the workspace offset
- Constrain dragging so grouped pieces cannot leave the workspace

## Testing
- ⚠️ `dotnet build PuzzleAM.sln` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68be04f3e7408320a4cef023dc4b0005