### PR TITLE
Refine layout and user list

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -23,7 +23,7 @@
 @code {
     private bool navOpen = false;
 
-    private string NavTabStyle => $"position:absolute;top:1rem;left:{(navOpen ? "250px" : "0")};transition:left 0.3s ease;z-index:1;";
+    private string NavTabStyle => $"position:fixed;top:1rem;left:{(navOpen ? "250px" : "0")};transition:left 0.3s ease;z-index:1001;";
 
     private void ToggleNav()
     {

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -26,7 +26,6 @@
 
         @if (!string.IsNullOrEmpty(RoomCode))
         {
-            <span>Room Code: @RoomCode</span>
             <button class="btn btn-outline-secondary copy-icon" @onclick="CopyRoomCode" title="Copy room code">
                 <img src="/lib/heroicons/clipboard.svg" alt="Copy room code" />
             </button>
@@ -44,6 +43,10 @@
 
 <div class="user-wrapper">
     <div class="user-panel @(userListVisible ? "open" : "closed")">
+        @if (!string.IsNullOrEmpty(RoomCode))
+        {
+            <div class="room-code">Room Code: @RoomCode</div>
+        }
         <h5>Users</h5>
         <ul>
             @foreach (var u in users)

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -2,8 +2,11 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    position: relative;
-    z-index: 1;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
 }
 
 .settings-panel {
@@ -25,20 +28,22 @@
 
 .user-wrapper {
     position: fixed;
-    top: 1rem;
+    top: 4.5rem;
     right: 1rem;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    z-index: 1;
+    z-index: 1000;
 }
 
 .user-panel {
     width: 200px;
-    background: #fff;
-    border: 1px solid #ccc;
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(0, 0, 0, 0.1);
     padding: 0.5rem;
-    border-radius: 0.25rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    backdrop-filter: blur(4px);
     max-height: 90vh;
     overflow-y: auto;
     transition: max-height 0.3s ease, opacity 0.3s ease;
@@ -62,6 +67,11 @@
     text-align: center;
     position: relative;
     z-index: 1;
+}
+
+.room-code {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Pin settings bar and user list to page top and restyle the user list with subtle transparency and shadowing
- Move room code display into the user list while keeping copy and leave buttons in settings bar
- Fix nav toggle positioning so the sidebar tab remains clickable above other elements

## Testing
- `dotnet build PuzzleAM.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be186467bc83208b72a26fede2c538