### PR TITLE
Synchronize sidebar and menu toggle state

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -3,7 +3,7 @@
 
 <div class="page">
     <div class="sidebar @(navOpen ? string.Empty : "closed")">
-        <NavMenu />
+        <NavMenu @bind-IsExpanded="navOpen" />
     </div>
     <Tab Class="nav-tab" IsOpen="navOpen" OnToggle="ToggleNav" style="@NavTabStyle" />
 

--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -4,7 +4,7 @@
     </div>
 </div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+<input type="checkbox" title="Navigation menu" class="navbar-toggler" @bind="IsExpanded" />
 
     <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
         <nav class="nav flex-column">
@@ -21,3 +21,10 @@
         </nav>
     </div>
 
+@code {
+    [Parameter]
+    public bool IsExpanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> IsExpandedChanged { get; set; }
+}


### PR DESCRIPTION
## Summary
- Bind NavMenu checkbox to layout's sidebar state
- Expose IsExpanded parameter on NavMenu for two-way binding

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a0f824c8320927a59c9f050573f