### PR TITLE
Ensure nav bar tab toggles navigation

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -28,6 +28,7 @@
     private void ToggleNav()
     {
         navOpen = !navOpen;
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
## Summary
- Re-render layout when nav tab is toggled so sidebar width updates correctly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1bb9445c832081bc1e16c91915a0