### PR TITLE
Propagate NavMenu expansion state to layout

### DIFF
--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -22,8 +22,23 @@
     </div>
 
 @code {
+    private bool _isExpanded;
+
     [Parameter]
-    public bool IsExpanded { get; set; }
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (_isExpanded == value)
+            {
+                return;
+            }
+
+            _isExpanded = value;
+            IsExpandedChanged.InvokeAsync(value);
+        }
+    }
 
     [Parameter]
     public EventCallback<bool> IsExpandedChanged { get; set; }


### PR DESCRIPTION
## Summary
- ensure NavMenu triggers `IsExpandedChanged` when toggled so layout `navOpen` stays in sync

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0d3c931483208b15fc7a30be95da