### PR TITLE
Reset puzzle timer when new puzzle is broadcast

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -161,6 +161,19 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     }
 
     [JSInvokable]
+    public Task PuzzleStateChanged(string imageDataUrl, int pieceCount)
+    {
+        this.imageDataUrl = imageDataUrl;
+        selectedPieces = pieceCount;
+        stopwatch.Reset();
+        elapsed = TimeSpan.Zero;
+        timer?.Dispose();
+        puzzleStarted = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
     public Task PuzzleLoaded()
     {
         if (puzzleStarted)

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -132,6 +132,9 @@ async function startHubConnection() {
     });
 
     hubConnection.on("BoardState", state => {
+        if (puzzleEventHandler) {
+            puzzleEventHandler.invokeMethodAsync('PuzzleStateChanged', state.imageDataUrl || '', state.pieceCount || 0);
+        }
         if (state.imageDataUrl) {
             window.createPuzzle(state.imageDataUrl, "puzzleContainer", state);
         }


### PR DESCRIPTION
## Summary
- Reset local puzzle timer and `puzzleStarted` flag whenever a new puzzle state is broadcast from the hub
- Notify the Blazor component of puzzle state changes from JavaScript

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf39b3a4cc83208e20b4121fc28e66