### PR TITLE
Add Puzzle AM logo to home page

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -25,6 +25,7 @@
 </div>
 
 <h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
+<img src="images/AM_logo.png" alt="Puzzle AM logo" class="d-block mx-auto" style="width:20vw;" />
 <div class="d-flex flex-column align-items-center justify-content-center" style="height:70vh;">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>
     <div class="input-group w-auto mb-2">


### PR DESCRIPTION
## Summary
- Show AM logo under the "Puzzle AM" title on the landing page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3bd3285c83209c314cd2795ce4da