### PR TITLE
Refine mobile settings layout

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -153,17 +153,15 @@ h1:focus {
 
 @media (max-width: 768px) {
     .settings-panel {
-        flex-direction: column;
-        width: 100%;
-        align-items: stretch;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        width: auto;
     }
 
     .settings-panel > * {
-        width: 100%;
-        margin-bottom: 0.5rem;
-    }
-
-    .settings-panel > *:last-child {
+        width: auto;
         margin-bottom: 0;
     }
 }


### PR DESCRIPTION
## Summary
- keep settings panel compact on mobile by using horizontal layout and automatic width

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4d7afa288320b247fb6f0b57d86c