### PR TITLE
Allow dragging pieces beneath timer and settings bar

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -7,6 +7,7 @@
     left: 0;
     width: 100%;
     z-index: 1000;
+    pointer-events: none;
 }
 
 .settings-panel {
@@ -14,6 +15,7 @@
     transition: max-height 0.3s ease, opacity 0.3s ease;
     max-height: 500px;
     opacity: 1;
+    pointer-events: auto;
 }
 
 .settings-panel.closed {
@@ -24,6 +26,7 @@
 ::deep(.settings-tab) {
     margin-top: 0.5rem;
     border-radius: 4px 4px 0 0;
+    pointer-events: auto;
 }
 
 .user-wrapper {


### PR DESCRIPTION
## Summary
- Prevent top overlay from blocking puzzle piece interaction by disabling pointer events on the wrapper
- Re-enable pointer interactions for the settings panel and toggle tab

## Testing
- `dotnet test` *(fails: current SDK 8.0 can't build projects targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf55a99a10832082f9f57de0775f87