### PR TITLE
Reduce spacing below landing page logo

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -26,7 +26,7 @@
 
 <h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
 <img src="images/AM_logo.png" alt="Puzzle AM logo" class="d-block mx-auto" style="width:20vw;" />
-<div class="d-flex flex-column align-items-center justify-content-center" style="height:70vh;">
+<div class="d-flex flex-column align-items-center mt-3">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>
     <div class="input-group w-auto mb-2">
         <input class="form-control" @bind="joinCode" placeholder="Enter room code" />


### PR DESCRIPTION
## Summary
- Move Create/Join Room controls up to tighten spacing beneath landing logo

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf55dcbbf48320967b61b37bfc3abc