### PR TITLE
Fix settings tab clickability

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -23,7 +23,7 @@
     opacity: 0;
 }
 
-::deep(.settings-tab) {
+::deep .settings-tab {
     margin-top: 0.5rem;
     border-radius: 4px 4px 0 0;
     pointer-events: auto;
@@ -83,7 +83,7 @@
         max-height: 80vh;
     }
 
-    ::deep(.settings-tab) {
+    ::deep .settings-tab {
         position: fixed;
         bottom: 1rem;
         right: 1rem;


### PR DESCRIPTION
## Summary
- Correct settings tab CSS selector syntax to ensure toggle button receives pointer events on all screen sizes.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf586007e08320912e8916f97ac4b7