### PR TITLE
Fix shadow display for connected puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -572,7 +572,6 @@ function updatePieceShadow(piece) {
 
     const shadows = [];
     const threshold = Math.min(pieceWidth, pieceHeight) * 0.05;
-
     const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
     if (bottomNeighbor && parseInt(bottomNeighbor.dataset.groupId) === groupId) {
         const expectedDx = parseFloat(bottomNeighbor.dataset.correctX) - pieceCorrectX;
@@ -588,6 +587,21 @@ function updatePieceShadow(piece) {
         shadows.push('drop-shadow(0 3px 6px rgba(0, 0, 0, 0.5))');
     }
 
+    const topNeighbor = row > 0 ? window.pieces[(row - 1) * window.puzzleCols + col] : null;
+    if (topNeighbor && parseInt(topNeighbor.dataset.groupId) === groupId) {
+        const expectedDx = parseFloat(topNeighbor.dataset.correctX) - pieceCorrectX;
+        const expectedDy = -pieceHeight;
+        const actualDx = parseFloat(topNeighbor.style.left) - parseFloat(piece.style.left);
+        const actualDy = parseFloat(topNeighbor.style.top) - parseFloat(piece.style.top);
+        const diffX = Math.abs(actualDx - expectedDx);
+        const diffY = Math.abs(actualDy - expectedDy);
+        if (diffX >= threshold || diffY >= threshold) {
+            shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
+        }
+    } else {
+        shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
+    }
+
     const rightNeighbor = col < window.puzzleCols - 1 ? window.pieces[row * window.puzzleCols + (col + 1)] : null;
     if (rightNeighbor && parseInt(rightNeighbor.dataset.groupId) === groupId) {
         const expectedDx = pieceWidth;
@@ -601,6 +615,21 @@ function updatePieceShadow(piece) {
         }
     } else {
         shadows.push('drop-shadow(3px 0 6px rgba(0, 0, 0, 0.5))');
+    }
+
+    const leftNeighbor = col > 0 ? window.pieces[row * window.puzzleCols + (col - 1)] : null;
+    if (leftNeighbor && parseInt(leftNeighbor.dataset.groupId) === groupId) {
+        const expectedDx = -pieceWidth;
+        const expectedDy = parseFloat(leftNeighbor.dataset.correctY) - pieceCorrectY;
+        const actualDx = parseFloat(leftNeighbor.style.left) - parseFloat(piece.style.left);
+        const actualDy = parseFloat(leftNeighbor.style.top) - parseFloat(piece.style.top);
+        const diffX = Math.abs(actualDx - expectedDx);
+        const diffY = Math.abs(actualDy - expectedDy);
+        if (diffX >= threshold || diffY >= threshold) {
+            shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
+        }
+    } else {
+        shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
     }
 
     piece.style.filter = shadows.length ? shadows.join(' ') : 'none';


### PR DESCRIPTION
## Summary
- Ensure puzzle pieces have shadows on all sides when created
- Remove shadows on sides that connect to other pieces to eliminate joining seams

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f2a9748832088faae9009693ea4