### PR TITLE
Tighten piece shadow tolerance and add top/left checks

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -571,7 +571,7 @@ function updatePieceShadow(piece) {
     const pieceHeight = parseFloat(piece.dataset.height);
 
     const shadows = [];
-    const threshold = Math.min(pieceWidth, pieceHeight) * 0.05;
+    const threshold = 2; // tighter tolerance in pixels
 
     const bottomNeighbor = row < window.puzzleRows - 1 ? window.pieces[(row + 1) * window.puzzleCols + col] : null;
     if (bottomNeighbor && parseInt(bottomNeighbor.dataset.groupId) === groupId) {
@@ -601,6 +601,36 @@ function updatePieceShadow(piece) {
         }
     } else {
         shadows.push('drop-shadow(3px 0 6px rgba(0, 0, 0, 0.5))');
+    }
+
+    const topNeighbor = row > 0 ? window.pieces[(row - 1) * window.puzzleCols + col] : null;
+    if (topNeighbor && parseInt(topNeighbor.dataset.groupId) === groupId) {
+        const expectedDx = parseFloat(topNeighbor.dataset.correctX) - pieceCorrectX;
+        const expectedDy = -pieceHeight;
+        const actualDx = parseFloat(topNeighbor.style.left) - parseFloat(piece.style.left);
+        const actualDy = parseFloat(topNeighbor.style.top) - parseFloat(piece.style.top);
+        const diffX = Math.abs(actualDx - expectedDx);
+        const diffY = Math.abs(actualDy - expectedDy);
+        if (diffX >= threshold || diffY >= threshold) {
+            shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
+        }
+    } else {
+        shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
+    }
+
+    const leftNeighbor = col > 0 ? window.pieces[row * window.puzzleCols + (col - 1)] : null;
+    if (leftNeighbor && parseInt(leftNeighbor.dataset.groupId) === groupId) {
+        const expectedDx = -pieceWidth;
+        const expectedDy = parseFloat(leftNeighbor.dataset.correctY) - pieceCorrectY;
+        const actualDx = parseFloat(leftNeighbor.style.left) - parseFloat(piece.style.left);
+        const actualDy = parseFloat(leftNeighbor.style.top) - parseFloat(piece.style.top);
+        const diffX = Math.abs(actualDx - expectedDx);
+        const diffY = Math.abs(actualDy - expectedDy);
+        if (diffX >= threshold || diffY >= threshold) {
+            shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
+        }
+    } else {
+        shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
     }
 
     piece.style.filter = shadows.length ? shadows.join(' ') : 'none';


### PR DESCRIPTION
## Summary
- use a fixed 2px tolerance for piece connection shadow detection
- extend shadow comparison to top and left neighbors

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c035164cb4832083a291a9d3514857