### PR TITLE
Ensure precise snapping of puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -736,11 +736,24 @@ function snapPiece(el) {
                 const diffY = actualDy - expectedDy;
 
                 if (Math.abs(diffX) < threshold && Math.abs(diffY) < threshold) {
+                    // Determine the new offset for the entire group based on each piece's
+                    // correct position to avoid accumulating rounding errors.
+                    const pieceOffsetX = pieceCurrentX - pieceCorrectX;
+                    const pieceOffsetY = pieceCurrentY - pieceCorrectY;
+                    const newOffsetX = pieceOffsetX + diffX;
+                    const newOffsetY = pieceOffsetY + diffY;
+
                     groupPieces.forEach(p => {
-                        const newLeft = Math.round(parseFloat(p.style.left) + diffX);
-                        const newTop = Math.round(parseFloat(p.style.top) + diffY);
+                        const correctX = parseFloat(p.dataset.correctX);
+                        const correctY = parseFloat(p.dataset.correctY);
+
+                        // Use a consistent subpixel rounding strategy to keep positions stable
+                        const newLeft = Math.round((correctX + newOffsetX) * 100) / 100;
+                        const newTop = Math.round((correctY + newOffsetY) * 100) / 100;
+
                         p.style.left = newLeft + 'px';
                         p.style.top = newTop + 'px';
+                        updatePieceShadow(p);
                         sendMove(p);
                     });
 


### PR DESCRIPTION
## Summary
- Preserve exact offsets when snapping puzzle piece groups by basing adjustments on each piece's `correctX`/`correctY`
- Use consistent subpixel rounding and update shadows after repositioning pieces

## Testing
- `dotnet test` *(fails: .NET SDK 8.0 does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c03516d39c83209d79b104d7fa53a2