### PR TITLE
Fix duplicate neighbor declarations

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -610,36 +610,6 @@ function updatePieceShadow(piece) {
         shadows.push('drop-shadow(3px 0 6px rgba(0, 0, 0, 0.5))');
     }
 
-    const topNeighbor = row > 0 ? window.pieces[(row - 1) * window.puzzleCols + col] : null;
-    if (topNeighbor && parseInt(topNeighbor.dataset.groupId) === groupId) {
-        const expectedDx = parseFloat(topNeighbor.dataset.correctX) - pieceCorrectX;
-        const expectedDy = -pieceHeight;
-        const actualDx = parseFloat(topNeighbor.style.left) - parseFloat(piece.style.left);
-        const actualDy = parseFloat(topNeighbor.style.top) - parseFloat(piece.style.top);
-        const diffX = Math.abs(actualDx - expectedDx);
-        const diffY = Math.abs(actualDy - expectedDy);
-        if (diffX >= threshold || diffY >= threshold) {
-            shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
-        }
-    } else {
-        shadows.push('drop-shadow(0 -3px 6px rgba(0, 0, 0, 0.5))');
-    }
-
-    const leftNeighbor = col > 0 ? window.pieces[row * window.puzzleCols + (col - 1)] : null;
-    if (leftNeighbor && parseInt(leftNeighbor.dataset.groupId) === groupId) {
-        const expectedDx = -pieceWidth;
-        const expectedDy = parseFloat(leftNeighbor.dataset.correctY) - pieceCorrectY;
-        const actualDx = parseFloat(leftNeighbor.style.left) - parseFloat(piece.style.left);
-        const actualDy = parseFloat(leftNeighbor.style.top) - parseFloat(piece.style.top);
-        const diffX = Math.abs(actualDx - expectedDx);
-        const diffY = Math.abs(actualDy - expectedDy);
-        if (diffX >= threshold || diffY >= threshold) {
-            shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
-        }
-    } else {
-        shadows.push('drop-shadow(-3px 0 6px rgba(0, 0, 0, 0.5))');
-    }
-
     piece.style.filter = shadows.length ? shadows.join(' ') : 'none';
 }
 


### PR DESCRIPTION
## Summary
- Remove duplicate topNeighbor and leftNeighbor declarations in `updatePieceShadow` to avoid redeclaration errors.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c036f013a48320833c89c567ce5bd5