### PR TITLE
Optimize image metadata loading and validation

### DIFF
--- a/PuzzleAM.Model/PuzzleState.cs
+++ b/PuzzleAM.Model/PuzzleState.cs
@@ -14,6 +14,8 @@ public class PuzzleState
 {
     public string ImageDataUrl { get; set; } = string.Empty;
     public int PieceCount { get; set; }
+    public int ImageWidth { get; set; }
+    public int ImageHeight { get; set; }
     // Dimensions of the puzzle board expressed in arbitrary units. Clients
     // will typically treat the board width and height as 1.0 and scale to the
     // available display area while piece coordinates are stored as percentages

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -249,7 +249,20 @@ window.setPuzzle = async function (roomCode, imageDataUrl, pieceCount) {
     await ensureHubConnection();
     if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
         try {
-            await hubConnection.invoke("SetPuzzle", roomCode, imageDataUrl, pieceCount);
+            let width = 0, height = 0;
+            if (imageDataUrl) {
+                const dims = await new Promise(resolve => {
+                    const img = new Image();
+                    img.onload = function () {
+                        resolve({ width: img.width, height: img.height });
+                    };
+                    img.onerror = function () { resolve({ width: 0, height: 0 }); };
+                    img.src = imageDataUrl;
+                });
+                width = dims.width;
+                height = dims.height;
+            }
+            await hubConnection.invoke("SetPuzzle", roomCode, imageDataUrl, pieceCount, width, height);
         } catch (error) {
             console.error('Error setting puzzle', error);
             alert('Failed to set puzzle. Please try again.');


### PR DESCRIPTION
## Summary
- Use `Image.Identify` in PuzzleHub to read image metadata without full decoding
- Cache image dimensions and accept client-supplied width/height to avoid repeated decoding
- Validate and reject overly large images early

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c06dfb6b248320bd302c5d37d157d2