### PR TITLE
Refactor puzzle piece generation to improve responsiveness

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -49,6 +49,16 @@
 
 <div id="puzzleContainer"></div>
 
+@if (loadProgress < 1)
+{
+    <div class="puzzle-loading">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <div class="mt-2">@((int)(loadProgress * 100))%</div>
+    </div>
+}
+
 <div class="user-wrapper">
     <div class="user-panel @(userListVisible ? "open" : "closed")">
         @if (!string.IsNullOrEmpty(RoomCode))

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -34,6 +34,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     private TimeSpan elapsed = TimeSpan.Zero;
     private bool completionRecorded;
     private bool puzzleStarted;
+    private double loadProgress = 1; // 1 means no loading overlay
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -192,6 +193,15 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
             InvokeAsync(StateHasChanged);
         }, null, 0, 1000);
         puzzleStarted = true;
+        loadProgress = 1;
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    public Task PuzzleProgress(double progress)
+    {
+        loadProgress = progress;
+        InvokeAsync(StateHasChanged);
         return Task.CompletedTask;
     }
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -67,6 +67,18 @@
     pointer-events: none;
 }
 
+.puzzle-loading {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 255, 255, 0.8);
+    padding: 1rem 2rem;
+    border-radius: 0.5rem;
+    text-align: center;
+    z-index: 2000;
+}
+
 .room-code {
     font-weight: 600;
     margin-bottom: 0.5rem;

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -313,9 +313,28 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
     }
     const img = new Image();
     img.onload = function () {
-        const rows = layout.rows;
-        const cols = layout.columns;
-        const piecesLayout = layout.pieces || [];
+        let rows = layout.rows;
+        let cols = layout.columns;
+
+        // On small screens lower the number of pieces to speed up generation
+        const smallScreen = window.innerWidth < 600 || window.innerHeight < 600;
+        if (smallScreen) {
+            const maxPieces = 200;
+            const total = rows * cols;
+            if (total > maxPieces) {
+                const factor = Math.sqrt(maxPieces / total);
+                rows = Math.max(1, Math.round(rows * factor));
+                cols = Math.max(1, Math.round(cols * factor));
+            }
+        }
+
+        window.currentLayout.rows = rows;
+        window.currentLayout.columns = cols;
+
+        let piecesLayout = layout.pieces || [];
+        if (rows !== layout.rows || cols !== layout.columns) {
+            piecesLayout = [];
+        }
         const pieceMap = {};
         piecesLayout.forEach(p => pieceMap[p.id] = p);
 
@@ -437,8 +456,25 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
         window.pieces = [];
         window.pieceIndex = {};
 
-        for (let y = 0; y < rows; y++) {
-            for (let x = 0; x < cols; x++) {
+        const totalPieces = rows * cols;
+        let pieceCounter = 0;
+
+        if (puzzleEventHandler) {
+            puzzleEventHandler.invokeMethodAsync('PuzzleProgress', 0);
+        }
+
+        const schedule = cb => {
+            if (window.requestIdleCallback) {
+                requestIdleCallback(cb);
+            } else {
+                requestAnimationFrame(() => cb({ timeRemaining: () => 0, didTimeout: true }));
+            }
+        };
+
+        const createBatch = deadline => {
+            while (pieceCounter < totalPieces && (deadline.timeRemaining() > 0 || deadline.didTimeout)) {
+                const y = Math.floor(pieceCounter / cols);
+                const x = pieceCounter % cols;
                 const top = y === 0 ? 0 : -vTabs[y - 1][x];
                 const left = x === 0 ? 0 : -hTabs[y][x - 1];
                 const right = x === cols - 1 ? 0 : (hTabs[y][x] = Math.random() > 0.5 ? 1 : -1);
@@ -449,17 +485,16 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
                 piece.height = pieceHeight + offset * 2;
                 piece.classList.add('puzzle-piece');
 
-                const pieceIndex = window.pieces.length;
-                const p = pieceMap[pieceIndex] || { left: 0, top: 0, groupId: pieceIndex };
+                const p = pieceMap[pieceCounter] || { left: 0, top: 0, groupId: pieceCounter };
                 piece.style.left = boardLeft + p.left * scaledWidth - window.workspaceOffset + 'px';
                 piece.style.top = boardTop + p.top * scaledHeight - window.workspaceOffset + 'px';
 
                 if (window.currentLayout) {
-                    window.currentLayout.pieces[pieceIndex] = {
-                        id: pieceIndex,
+                    window.currentLayout.pieces[pieceCounter] = {
+                        id: pieceCounter,
                         left: p.left,
                         top: p.top,
-                        groupId: p.groupId !== undefined ? p.groupId : pieceIndex
+                        groupId: p.groupId !== undefined ? p.groupId : pieceCounter
                     };
                 }
 
@@ -469,8 +504,8 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
                 piece.dataset.correctY = correctY;
                 piece.dataset.width = pieceWidth;
                 piece.dataset.height = pieceHeight;
-                piece.dataset.groupId = p.groupId !== undefined ? p.groupId : pieceIndex;
-                piece.dataset.pieceId = pieceIndex;
+                piece.dataset.groupId = p.groupId !== undefined ? p.groupId : pieceCounter;
+                piece.dataset.pieceId = pieceCounter;
                 piece.dataset.row = y;
                 piece.dataset.col = x;
 
@@ -497,13 +532,24 @@ window.createPuzzle = function (imageDataUrl, containerId, layout) {
                 window.pieces.push(piece);
                 window.pieceIndex[`${y},${x}`] = piece;
                 makeDraggable(piece, workspace);
+
+                pieceCounter++;
+                if (puzzleEventHandler) {
+                    puzzleEventHandler.invokeMethodAsync('PuzzleProgress', pieceCounter / totalPieces);
+                }
             }
-        }
-        updateAllShadows();
-        playStartSound();
-        if (puzzleEventHandler) {
-            puzzleEventHandler.invokeMethodAsync('PuzzleLoaded');
-        }
+            if (pieceCounter < totalPieces) {
+                schedule(createBatch);
+            } else {
+                updateAllShadows();
+                playStartSound();
+                if (puzzleEventHandler) {
+                    puzzleEventHandler.invokeMethodAsync('PuzzleLoaded');
+                }
+            }
+        };
+
+        schedule(createBatch);
     };
     img.src = imageDataUrl;
 };


### PR DESCRIPTION
## Summary
- Create puzzle pieces incrementally using requestIdleCallback to avoid blocking the main thread
- Emit progress updates and show loading spinner while pieces are generated
- Trim puzzle piece count on small screens

## Testing
- `dotnet build PuzzleAM.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c06dfc442c8320a7f1e68dd70c32ac