### PR TITLE
Avoid preview during puzzle upload and handle progress errors

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -48,10 +48,6 @@
 
 
 <div id="puzzleContainer">
-    @if (!string.IsNullOrEmpty(previewUrl))
-    {
-        <img src="@previewUrl" class="preview-image" />
-    }
     @if (isLoading)
     {
         <div class="loading-indicator">

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -14,7 +14,6 @@ namespace PuzzleAM.Components.Pages;
 public partial class PuzzleGame : ComponentBase, IAsyncDisposable
 {
     private string? imageDataUrl;
-    private string? previewUrl;
     private bool isLoading;
     private string? loadError;
     private CancellationTokenSource? imageCts;
@@ -113,10 +112,6 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         try
         {
             isLoading = true;
-            // show a preview immediately
-            previewUrl = await JS.InvokeAsync<string>("getImagePreviewUrl", "imageLoader");
-            StateHasChanged();
-
             // resize and convert to base64 on a background thread
             imageDataUrl = await JS.InvokeAsync<string>("resizeImage", imageCts.Token, "imageLoader", 1920, 1080);
 
@@ -124,10 +119,9 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
             elapsed = TimeSpan.Zero;
             timer?.Dispose();
             puzzleStarted = false;
-            if (!string.IsNullOrEmpty(RoomCode) && imageDataUrl is not null)
+            if (!string.IsNullOrEmpty(RoomCode) && joined && imageDataUrl is not null)
             {
                 await JS.InvokeVoidAsync("setPuzzle", RoomCode, imageDataUrl, selectedPieces);
-                previewUrl = null;
             }
         }
         catch (OperationCanceledException)

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -84,11 +84,6 @@
     margin-bottom: 0.5rem;
 }
 
-.preview-image {
-    max-width: 100%;
-    height: auto;
-}
-
 .loading-indicator {
     margin-top: 1rem;
     text-align: center;


### PR DESCRIPTION
## Summary
- Remove preview image when loading a new puzzle
- Only send puzzle data after room join completes
- Catch puzzle progress events to avoid unhandled connection errors

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c0718578b083209b243049de167b65