### PR TITLE
Handle puzzle completion DB errors

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -251,24 +251,31 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
             StateHasChanged();
         }
 
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        var user = authState.User;
-        if (user.Identity?.IsAuthenticated == true && !string.IsNullOrEmpty(imageDataUrl))
+        try
         {
-            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            if (userId is not null)
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            var user = authState.User;
+            if (user.Identity?.IsAuthenticated == true && !string.IsNullOrEmpty(imageDataUrl))
             {
-                var puzzle = new CompletedPuzzle
+                var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (userId is not null)
                 {
-                    UserId = userId,
-                    UserName = user.Identity?.Name,
-                    ImageDataUrl = imageDataUrl,
-                    PieceCount = selectedPieces,
-                    TimeToComplete = elapsed
-                };
-                Db.CompletedPuzzles.Add(puzzle);
-                await Db.SaveChangesAsync();
+                    var puzzle = new CompletedPuzzle
+                    {
+                        UserId = userId,
+                        UserName = user.Identity?.Name,
+                        ImageDataUrl = imageDataUrl,
+                        PieceCount = selectedPieces,
+                        TimeToComplete = elapsed
+                    };
+                    Db.CompletedPuzzles.Add(puzzle);
+                    await Db.SaveChangesAsync();
+                }
             }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error recording completed puzzle");
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent circuit crashes by catching and logging database errors when recording puzzle completion

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c073cdfe948320a949fbe376575cda