### PR TITLE
Replace JS click handler with Blazor method in NavMenu

### DIFF
--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -4,9 +4,9 @@
     </div>
 </div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" @bind="IsExpanded" />
+<input type="checkbox" title="Navigation menu" class="navbar-toggler" @bind="IsExpanded" @onclick:stopPropagation />
 
-    <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
+    <div class="nav-scrollable" @onclick="CloseMenu">
         <nav class="nav flex-column">
             <NavLink class="nav-link" href="/" Match="NavLinkMatch.All">
                 <img src="/lib/heroicons/home.svg" alt="Home icon" /> Home
@@ -42,4 +42,6 @@
 
     [Parameter]
     public EventCallback<bool> IsExpandedChanged { get; set; }
+
+    private void CloseMenu(MouseEventArgs e) => IsExpanded = false;
 }


### PR DESCRIPTION
## Summary
- use Blazor `@onclick` to close NavMenu instead of inline JS
- prevent menu toggle click from bubbling to CloseMenu
- add `CloseMenu` helper method

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a67451388320bba7067447e5fce1