### PR TITLE
Use CSS class for navigation tab

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
     <div class="sidebar @(navOpen ? string.Empty : "closed")">
         <NavMenu @bind-IsExpanded="navOpen" />
     </div>
-    <Tab Class="nav-tab" IsOpen="navOpen" OnToggle="ToggleNav" style="@NavTabStyle" />
+    <Tab Class="nav-tab @(navOpen ? "open" : "closed")" IsOpen="navOpen" OnToggle="ToggleNav" />
 
     <main>
         <article class="content px-4">
@@ -22,8 +22,6 @@
 
 @code {
     private bool navOpen = false;
-
-    private string NavTabStyle => $"position:fixed;top:1rem;left:{(navOpen ? "250px" : "0")};transition:left 0.3s ease;z-index:1001;";
 
     private void ToggleNav()
     {

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -8,6 +8,21 @@ main {
     flex: 1;
 }
 
+.nav-tab {
+    position: fixed;
+    top: 1rem;
+    transition: left 0.3s ease;
+    z-index: 1001;
+}
+
+.nav-tab.open {
+    left: 250px;
+}
+
+.nav-tab.closed {
+    left: 0;
+}
+
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
     overflow: hidden;


### PR DESCRIPTION
## Summary
- replace inline nav tab styling with dynamic CSS classes

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1afba60688320b9eb81e08b17761f