### PR TITLE
Fix nav tab style scope

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -8,21 +8,6 @@ main {
     flex: 1;
 }
 
-.nav-tab {
-    position: fixed;
-    top: 1rem;
-    transition: left 0.3s ease;
-    z-index: 1001;
-}
-
-.nav-tab.open {
-    left: 250px;
-}
-
-.nav-tab.closed {
-    left: 0;
-}
-
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
     overflow: hidden;

--- a/PuzzleAM/Components/Shared/Tab.razor.css
+++ b/PuzzleAM/Components/Shared/Tab.razor.css
@@ -11,3 +11,18 @@
     justify-content: center;
     padding: 0;
 }
+
+.nav-tab {
+    position: fixed;
+    top: 1rem;
+    transition: left 0.3s ease;
+    z-index: 1001;
+}
+
+.nav-tab.open {
+    left: 250px;
+}
+
+.nav-tab.closed {
+    left: 0;
+}


### PR DESCRIPTION
## Summary
- Move nav toggle positioning rules from MainLayout.razor.css to Tab.razor.css so toggle button uses fixed placement and transitions
- Remove nav-tab styling from MainLayout's scoped CSS

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ed2d20908320940284c87680781b