### PR TITLE
Ensure nav tab remains clickable when sidebar is closed

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -2,10 +2,12 @@
 @inject IJSRuntime JS
 
 <div class="page">
-    <div class="sidebar @(navOpen ? string.Empty : "closed")">
-        <NavMenu @bind-IsExpanded="navOpen" />
+    <div class="nav-wrapper">
+        <div class="sidebar @(navOpen ? string.Empty : "closed")">
+            <NavMenu @bind-IsExpanded="navOpen" />
+        </div>
+        <Tab Class="nav-tab @(navOpen ? "open" : "closed")" IsOpen="navOpen" OnToggle="ToggleNav" />
     </div>
-    <Tab Class="nav-tab @(navOpen ? "open" : "closed")" IsOpen="navOpen" OnToggle="ToggleNav" />
 
     <main>
         <article class="content px-4">

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -17,6 +17,16 @@ main {
 
 .sidebar.closed {
     width: 0;
+    pointer-events: none;
+}
+
+.nav-wrapper {
+    pointer-events: none;
+}
+
+.nav-wrapper .sidebar,
+.nav-wrapper .nav-tab {
+    pointer-events: auto;
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
## Summary
- Wrap the sidebar and nav toggle button in a `nav-wrapper` container
- Disable pointer events on the closed sidebar and wrapper while keeping the toggle clickable

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c211847650832081518791015c1e19