### PR TITLE
Fix nav tab pointer events

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -2,12 +2,10 @@
 @inject IJSRuntime JS
 
 <div class="page">
-    <div class="nav-wrapper">
-        <div class="sidebar @(navOpen ? string.Empty : "closed")">
-            <NavMenu @bind-IsExpanded="navOpen" />
-        </div>
-        <Tab Class="nav-tab @(navOpen ? "open" : "closed")" IsOpen="navOpen" OnToggle="ToggleNav" />
+    <div class="sidebar @(navOpen ? string.Empty : "closed")">
+        <NavMenu @bind-IsExpanded="navOpen" />
     </div>
+    <Tab Class=@($"nav-tab {(navOpen ? "open" : "closed")}") IsOpen="navOpen" OnToggle="ToggleNav" />
 
     <main>
         <article class="content px-4">

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -20,15 +20,6 @@ main {
     pointer-events: none;
 }
 
-.nav-wrapper {
-    pointer-events: none;
-}
-
-.nav-wrapper .sidebar,
-.nav-wrapper .nav-tab {
-    pointer-events: auto;
-}
-
 @media (min-width: 641px) {
     .page {
         flex-direction: row;


### PR DESCRIPTION
## Summary
- remove wrapper disabling nav tab clicks
- keep sidebar closed from intercepting pointer events

## Testing
- `dotnet build`
- `dotnet run --project PuzzleAM/PuzzleAM.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c21fe84e4c8320a5a9df2083dd9949