### PR TITLE
Add collapsible sidebar with user-specific gallery link

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -1,6 +1,20 @@
 @inherits LayoutComponentBase
 
-<main>
+<Tab IsOpen="@isNavOpen"
+     OnToggle="ToggleNav"
+     Class="nav-tab @(isNavOpen ? "open" : "closed")" />
+
+<nav class="side-nav @(isNavOpen ? "open" : string.Empty)">
+    <ul>
+        <AuthorizeView>
+            <Authorized>
+                <li><NavLink href="/gallery">Gallery</NavLink></li>
+            </Authorized>
+        </AuthorizeView>
+    </ul>
+</nav>
+
+<main class="main-content @(isNavOpen ? "shifted" : string.Empty)">
     <article class="content px-4">
         @Body
     </article>
@@ -11,3 +25,12 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    private bool isNavOpen;
+
+    private void ToggleNav()
+    {
+        isNavOpen = !isNavOpen;
+    }
+}

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -18,3 +18,42 @@
     right: 0.75rem;
     top: 0.5rem;
 }
+.side-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 250px;
+    height: 100vh;
+    background-color: #f8f9fa;
+    transform: translateX(-250px);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    padding-top: 1rem;
+}
+
+.side-nav.open {
+    transform: translateX(0);
+}
+
+.side-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.side-nav li {
+    padding: 0.5rem 1rem;
+}
+
+.side-nav a {
+    text-decoration: none;
+    color: rgba(5, 39, 103, 0.8);
+}
+
+.main-content {
+    transition: margin-left 0.3s ease;
+}
+
+.main-content.shifted {
+    margin-left: 250px;
+}


### PR DESCRIPTION
## Summary
- add left-hand navigation bar with toggleable tab
- show Gallery link for authenticated users and space for other navigation items
- style layout to support sliding sidebar and shifted main content

## Testing
- `dotnet build PuzzleAM.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c45df63c3483209909631f76cc9f31