### PR TITLE
Fix tab toggle click handling

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -7,7 +7,9 @@
     left: 0;
     width: 100%;
     z-index: 1000;
-    pointer-events: none;
+    /* Allow pointer events so interactive elements like the settings tab
+       can receive click events.  Previously, "pointer-events: none" blocked
+       clicks from reaching the Tab component. */
 }
 
 .settings-panel {


### PR DESCRIPTION
## Summary
- Allow settings tab to receive clicks by dropping `pointer-events: none` from the wrapper

## Testing
- `/root/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c4669a63b88320b318da580c86b5af