### PR TITLE
Ensure sidebar tab remains clickable

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -1,11 +1,13 @@
 @inherits LayoutComponentBase
 @inject IJSRuntime JS
 
+
+<Tab Class=@($"nav-tab {(navOpen ? "open" : "closed")}") IsOpen="navOpen" OnToggle="ToggleNav" />
+
 <div class="page">
     <div class="sidebar @(navOpen ? string.Empty : "closed")">
         <NavMenu @bind-IsExpanded="navOpen" />
     </div>
-    <Tab Class=@($"nav-tab {(navOpen ? "open" : "closed")}") IsOpen="navOpen" OnToggle="ToggleNav" />
 
     <main>
         <article class="content px-4">

--- a/PuzzleAM/Components/Shared/Tab.razor.css
+++ b/PuzzleAM/Components/Shared/Tab.razor.css
@@ -17,6 +17,7 @@
     top: 1rem;
     transition: left 0.3s ease;
     z-index: 1001;
+    pointer-events: auto;
 }
 
 .nav-tab.open {


### PR DESCRIPTION
## Summary
- Ensure sidebar toggle tab sits above the sidebar and accepts pointer input
- Move `Tab` component outside of the layout's `.page` container to avoid sidebar pointer suppression

## Testing
- `dotnet build PuzzleAM.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c028ea388320b46de5de5ec87f46