### PR TITLE
Fix sidebar toggle overlap and tab stacking

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -2,8 +2,6 @@
 @inject IJSRuntime JS
 
 
-<Tab Class=@($"nav-tab {(navOpen ? "open" : "closed")}") IsOpen="navOpen" OnToggle="ToggleNav" />
-
 <div class="page">
     <div class="sidebar @(navOpen ? string.Empty : "closed")">
         <NavMenu @bind-IsExpanded="navOpen" />
@@ -15,6 +13,8 @@
         </article>
     </main>
 </div>
+
+<Tab Class=@($"nav-tab {(navOpen ? "open" : "closed")}") IsOpen="navOpen" OnToggle="ToggleNav" />
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -18,6 +18,8 @@ main {
 .sidebar.closed {
     width: 0;
     pointer-events: none;
+    position: fixed;
+    left: -250px;
 }
 
 @media (min-width: 641px) {

--- a/PuzzleAM/Components/Shared/Tab.razor.css
+++ b/PuzzleAM/Components/Shared/Tab.razor.css
@@ -16,7 +16,7 @@
     position: fixed;
     top: 1rem;
     transition: left 0.3s ease;
-    z-index: 1001;
+    z-index: 2000;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- move closed sidebar off-canvas to avoid blocking toggle
- raise nav tab z-index above overlays
- position Tab component after page content

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c3ee62b483209ccd2f2757fd2ef4