### PR TITLE
Ensure nav menu toggle propagates to parent

### DIFF
--- a/PuzzleAM/Components/Layout/NavMenu.razor
+++ b/PuzzleAM/Components/Layout/NavMenu.razor
@@ -22,11 +22,28 @@
     </div>
 
 @code {
+    private bool _isExpanded;
+
     [Parameter]
-    public bool IsExpanded { get; set; }
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set
+        {
+            if (_isExpanded != value)
+            {
+                _isExpanded = value;
+                IsExpandedChanged.InvokeAsync(value);
+            }
+        }
+    }
 
     [Parameter]
     public EventCallback<bool> IsExpandedChanged { get; set; }
 
-    private Task CloseMenu(MouseEventArgs e) => IsExpandedChanged.InvokeAsync(false);
+    private Task CloseMenu(MouseEventArgs e)
+    {
+        IsExpanded = false;
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
## Summary
- invoke `IsExpandedChanged` whenever the nav menu checkbox toggles
- rely on property setter to notify parent and update state when closing the menu

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c55345c7408320a36b23a25e868c14