### PR TITLE
Persist completed puzzle images per user

### DIFF
--- a/PuzzleAM/CompletedPuzzle.cs
+++ b/PuzzleAM/CompletedPuzzle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace PuzzleAM;
 
@@ -7,7 +8,11 @@ public class CompletedPuzzle
     public int Id { get; set; }
     public string UserId { get; set; } = string.Empty;
     public string? UserName { get; set; }
-    public string ImageDataUrl { get; set; } = string.Empty;
+    public byte[] ImageData { get; set; } = Array.Empty<byte>();
+    public string ContentType { get; set; } = string.Empty;
     public int PieceCount { get; set; }
     public TimeSpan TimeToComplete { get; set; }
+
+    [NotMapped]
+    public string ImageDataUrl => $"data:{ContentType};base64,{Convert.ToBase64String(ImageData)}";
 }

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -44,7 +44,8 @@ using (var scope = app.Services.CreateScope())
             Id INTEGER PRIMARY KEY AUTOINCREMENT,
             UserId TEXT NOT NULL,
             UserName TEXT NULL,
-            ImageDataUrl TEXT NOT NULL,
+            ImageData BLOB NOT NULL,
+            ContentType TEXT NOT NULL,
             PieceCount INTEGER NOT NULL,
             TimeToComplete TEXT NOT NULL
         );");


### PR DESCRIPTION
## Summary
- persist puzzle images as binary data tied to the user
- capture uploaded puzzle image bytes and content type for storage
- create database table columns to store image data and content type

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c562c822988320af7ed3b1f6558ae5