### PR TITLE
fix: center mobile user list

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -76,13 +76,16 @@
 }
 
 @media (max-width: 768px) {
-    .user-panel {
-        width: 80vw;
-        left: 50%;
-        right: auto;
+    .user-wrapper {
         top: 10vh;
-        transform: translateX(-50%);
-        z-index: 1000;
+        left: 0;
+        right: 0;
+        align-items: center;
+    }
+
+    .user-panel {
+        width: calc(100% - 2rem);
+        transform: none;
         max-height: 80vh;
     }
 


### PR DESCRIPTION
## Summary
- ensure user panel flexes to fit the mobile viewport and stays centered

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5711164f4832097f21a28b1d04589