### PR TITLE
Fix snap threshold rounding

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -726,12 +726,14 @@ function snapPiece(el) {
 
                 const actualDx = parseFloat(neighbor.style.left) - pieceCurrentX;
                 const actualDy = parseFloat(neighbor.style.top) - pieceCurrentY;
-                // Rounding the differences prevents fractional pixel values that can
-                // create visible seams between connected pieces.
-                const diffX = Math.round(actualDx - expectedDx);
-                const diffY = Math.round(actualDy - expectedDy);
+                const offsetX = actualDx - expectedDx;
+                const offsetY = actualDy - expectedDy;
 
-                if (Math.abs(diffX) < threshold && Math.abs(diffY) < threshold) {
+                // Compare using the raw offsets so near-threshold pieces still connect,
+                // then round the adjustment applied to the pieces to avoid seams.
+                if (Math.abs(offsetX) < threshold && Math.abs(offsetY) < threshold) {
+                    const diffX = Math.round(offsetX);
+                    const diffY = Math.round(offsetY);
                     groupPieces.forEach(p => {
                         p.style.left = (parseFloat(p.style.left) + diffX) + 'px';
                         p.style.top = (parseFloat(p.style.top) + diffY) + 'px';


### PR DESCRIPTION
## Summary
- adjust puzzle snapping logic to compare raw offsets against threshold before rounding to avoid missed connections

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c7a3e50483208e78a06f3a839137