### PR TITLE
Fix right and bottom tab shapes in puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -540,7 +540,7 @@ function drawPiecePath(ctx, w, h, top, right, bottom, left, offset) {
         const endY = centerY + radius;
         ctx.lineTo(offset + w, startY);
         ctx.lineTo(offset + w + neck * dir, startY);
-        ctx.arc(offset + w + neck * dir, centerY, radius, Math.PI / 2, -Math.PI / 2, dir === 1);
+        ctx.arc(offset + w + neck * dir, centerY, radius, -Math.PI / 2, Math.PI / 2, dir === -1);
         ctx.lineTo(offset + w + neck * dir, endY);
         ctx.lineTo(offset + w, endY);
         ctx.lineTo(offset + w, offset + h);
@@ -552,11 +552,11 @@ function drawPiecePath(ctx, w, h, top, right, bottom, left, offset) {
     } else {
         const dir = bottom;
         const centerX = offset + w / 2;
-        const startX = centerX + radius;
-        const endX = centerX - radius;
+        const startX = centerX - radius;
+        const endX = centerX + radius;
         ctx.lineTo(startX, offset + h);
         ctx.lineTo(startX, offset + h + neck * dir);
-        ctx.arc(centerX, offset + h + neck * dir, radius, 0, Math.PI, dir === -1);
+        ctx.arc(centerX, offset + h + neck * dir, radius, Math.PI, 0, dir === -1);
         ctx.lineTo(endX, offset + h + neck * dir);
         ctx.lineTo(endX, offset + h);
         ctx.lineTo(offset, offset + h);


### PR DESCRIPTION
## Summary
- Correct orientation for right-side tabs by fixing arc start/end angles
- Align bottom tabs with matching pieces by standardizing tab path

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cff97680832083816d5f91d618aa