### PR TITLE
Fix bottom edge arc orientation for puzzle pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -552,11 +552,13 @@ function drawPiecePath(ctx, w, h, top, right, bottom, left, offset) {
     } else {
         const dir = bottom;
         const centerX = offset + w / 2;
-        const startX = centerX - radius;
-        const endX = centerX + radius;
+        const startX = centerX + radius;
+        const endX = centerX - radius;
         ctx.lineTo(startX, offset + h);
         ctx.lineTo(startX, offset + h + neck * dir);
-        ctx.arc(centerX, offset + h + neck * dir, radius, Math.PI, 0, dir === -1);
+        const startAngle = dir === 1 ? 0 : Math.PI;
+        const endAngle = dir === 1 ? Math.PI : 0;
+        ctx.arc(centerX, offset + h + neck * dir, radius, startAngle, endAngle, false);
         ctx.lineTo(endX, offset + h + neck * dir);
         ctx.lineTo(endX, offset + h);
         ctx.lineTo(offset, offset + h);


### PR DESCRIPTION
## Summary
- compute bottom edge arc start/end angles from tab direction

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fd93e4848320b0174035c2910d22