### PR TITLE
Fix bottom edge tab orientations in jigsaw pieces

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -556,9 +556,7 @@ function drawPiecePath(ctx, w, h, top, right, bottom, left, offset) {
         const endX = centerX - radius;
         ctx.lineTo(startX, offset + h);
         ctx.lineTo(startX, offset + h + neck * dir);
-        const startAngle = dir === 1 ? 0 : Math.PI;
-        const endAngle = dir === 1 ? Math.PI : 0;
-        ctx.arc(centerX, offset + h + neck * dir, radius, startAngle, endAngle, false);
+        ctx.arc(centerX, offset + h + neck * dir, radius, 0, Math.PI, dir === -1);
         ctx.lineTo(endX, offset + h + neck * dir);
         ctx.lineTo(endX, offset + h);
         ctx.lineTo(offset, offset + h);


### PR DESCRIPTION
## Summary
- Correct bottom edge path to render both inward and outward tabs without rectangular or truncated shapes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c6010f829483209d22e0a615723ff6