### PR TITLE
Resize images client-side before upload

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -13,7 +13,7 @@
             }
         </select>
 
-        <InputFile id="imageLoader" OnChange="OnInputFileChange" class="d-none" />
+        <InputFile id="imageLoader" OnChange="HandleImageUpload" class="d-none" @ref="fileInput" />
         <label for="imageLoader" class="btn btn-primary load-icon" title="Load Image">
             <img src="/lib/heroicons/image.svg" alt="Load image icon" />
         </label>


### PR DESCRIPTION
## Summary
- Compress images on the client with a canvas and send the reduced data URL to the server.
- Parse the provided data URL on the server and remove ImageSharp-based resizing.
- Trigger client-side processing when a file is selected to avoid uploading full-size images.

## Testing
- `~/.dotnet/dotnet build PuzzleAM.sln`
- `~/.dotnet/dotnet test PuzzleAM.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c6aa4cb3788320aac9ef5210f9e9e0