### PR TITLE
Use default PNG compression for faster uploads

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -117,9 +117,9 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
 
         using var ms = new MemoryStream();
         var contentType = file.ContentType == "image/png" ? "image/png" : "image/jpeg";
-        // Use stronger compression for both JPEG and PNG uploads
+        // Use moderate compression for both JPEG and PNG uploads
         IImageEncoder encoder = contentType == "image/png"
-            ? new PngEncoder { CompressionLevel = PngCompressionLevel.BestCompression }
+            ? new PngEncoder { CompressionLevel = PngCompressionLevel.DefaultCompression }
             : new JpegEncoder { Quality = 60 };
 
         await image.SaveAsync(ms, encoder);


### PR DESCRIPTION
## Summary
- speed up puzzle image uploads by using default PNG compression instead of best compression

## Testing
- `~/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c75c6a2a748320aed7769b6e68fe5c