### PR TITLE
Adjust puzzle image resizing based on device width

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -101,8 +101,14 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {
-        // Resize large images more aggressively so we transmit less data
-        const int maxDimension = 800;
+        // Resize large images more aggressively so we transmit less data. Adjust the
+        // maximum dimension based on the device width so smaller devices transmit
+        // proportionally smaller images.
+        var deviceWidth = await JS.InvokeAsync<int>("eval", "window.innerWidth");
+        var maxDimension = deviceWidth < 576 ? 400
+            : deviceWidth < 992 ? 600
+            : 800;
+
         var file = e.File;
         await using var stream = file.OpenReadStream(10 * 1024 * 1024);
         using var image = await Image.LoadAsync(stream);


### PR DESCRIPTION
## Summary
- Resize uploaded images based on device width to reduce payload on small screens

## Testing
- `dotnet build` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c6b24b08320a4b2bcdc87aacc25