### PR TITLE
Handle pending puzzle upload while hub reconnects

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -302,8 +302,16 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         sendingPendingPuzzle = true;
         try
         {
-            await JS.InvokeVoidAsync("setPuzzle", RoomCode, pendingImageDataUrl, pendingPieceCount);
-            puzzleUploadPending = false;
+            var puzzleSet = await JS.InvokeAsync<bool>("setPuzzle", RoomCode, pendingImageDataUrl, pendingPieceCount);
+            if (puzzleSet)
+            {
+                puzzleUploadPending = false;
+            }
+            else
+            {
+                puzzleUploadPending = true;
+                Logger.LogInformation("Delaying puzzle upload until the connection is restored.");
+            }
         }
         catch (Exception ex) when (IsDisconnectedException(ex))
         {


### PR DESCRIPTION
## Summary
- wait for the SignalR hub to reconnect before invoking SetPuzzle and return a status flag from the JS helper
- keep the pending upload flag set until the hub confirms the puzzle was sent from the Blazor component and log when it defers

## Testing
- dotnet build PuzzleAM.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb39bb447483209f6fbab517aabd3e