### PR TITLE
Retry pending puzzle upload after hub reconnection

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -223,6 +223,16 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     }
 
     [JSInvokable]
+    public async Task OnHubReconnected()
+    {
+        await TrySendPendingPuzzleAsync();
+        if (puzzleUploadPending)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    [JSInvokable]
     public Task PuzzleLoaded()
     {
         if (puzzleStarted)

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -116,6 +116,13 @@ async function startHubConnection() {
         if (currentRoomCode) {
             try {
                 await hubConnection.invoke("JoinRoom", currentRoomCode);
+                if (puzzleEventHandler) {
+                    try {
+                        await puzzleEventHandler.invokeMethodAsync("OnHubReconnected");
+                    } catch (err) {
+                        console.error('Error notifying reconnection handler', err);
+                    }
+                }
             } catch (e) {
                 console.error('Error rejoining room', e);
             }


### PR DESCRIPTION
## Summary
- notify the .NET puzzle event handler once the SignalR hub connection rejoins a room so it can react to reconnections
- add a JS-invokable handler in the puzzle game component that retries pending puzzle uploads when reconnection occurs and refreshes UI state if needed

## Testing
- `dotnet build PuzzleAM.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cb39bbb07c8320a8ea23135ab530ac