### PR TITLE
Add loading overlay during puzzle generation

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor
@@ -46,6 +46,16 @@
     <div class="timer-display">Time: @elapsed.ToString(@"hh\:mm\:ss")</div>
 </div>
 
+@if (isPuzzleLoading)
+{
+    <div class="loading-overlay" role="status" aria-live="polite">
+        <div class="loading-content">
+            <div class="spinner-border text-light" role="presentation"></div>
+            <span class="loading-text">Preparing puzzle...</span>
+        </div>
+    </div>
+}
+
 
 <div id="puzzleContainer"></div>
 

--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.css
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.css
@@ -75,6 +75,38 @@
     margin-bottom: 0.5rem;
 }
 
+.loading-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(15, 15, 15, 0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+    backdrop-filter: blur(2px);
+}
+
+.loading-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    color: #fff;
+    text-align: center;
+}
+
+.loading-content .spinner-border {
+    width: 3rem;
+    height: 3rem;
+}
+
+.loading-text {
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
 @media (max-width: 768px) {
     .user-wrapper {
         top: 10vh;


### PR DESCRIPTION
## Summary
- add a modal loading overlay that blocks interaction while a puzzle is being prepared
- surface puzzle loading state from the JavaScript puzzle builder back to Blazor
- style the overlay to provide feedback until puzzle pieces are created

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4557c7e88320b7154791e3185886