### PR TITLE
Implement collaborative puzzle piece locking

### DIFF
--- a/PuzzleAM.Model/PuzzleState.cs
+++ b/PuzzleAM.Model/PuzzleState.cs
@@ -29,4 +29,7 @@ public class PuzzleState
 
     public ConcurrentDictionary<int, PiecePosition> Pieces { get; } = new();
     public ConcurrentDictionary<string, string> Users { get; } = new();
+    public ConcurrentDictionary<int, string> PieceLocks { get; } = new();
+
+    public object SyncRoot { get; } = new();
 }

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -101,6 +101,12 @@ h1:focus {
     z-index: 1;
 }
 
+.puzzle-piece.locked {
+    cursor: not-allowed;
+    filter: grayscale(0.4);
+    opacity: 0.75;
+}
+
 .settings-panel {
     background-color: #ffffff;
     padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- add server-side tracking for piece locks per room and reject move commands from non-owners
- broadcast lock and unlock events so clients know when pieces are in use and clear locks when users leave
- update the web client to request/release locks, ignore pieces held by others, and highlight locked pieces

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d970807d98832095a7bd051b802c44