### PR TITLE
Update favicon to use AM logo

### DIFF
--- a/PuzzleAM/Components/App.razor
+++ b/PuzzleAM/Components/App.razor
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["PuzzleAM.styles.css"]" />
     <ImportMap />
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="@Assets["images/AM_logo.png"]" />
     <HeadOutlet />
 </head>
 


### PR DESCRIPTION
## Summary
- update the application HTML head to reference the AM logo as the favicon so the browser tab displays the correct branding

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d97b3e890883208f15ad86f41c17a5