### PR TITLE
Align sidebar spacing with shared width variable

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -1,3 +1,7 @@
+:root {
+    --sidebar-width: 100vw;
+}
+
 .page {
     position: relative;
     display: flex;
@@ -12,23 +16,26 @@ main {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
     overflow: hidden;
     transition: width 0.3s ease;
-    width: 250px;
+    width: var(--sidebar-width);
 }
 
 .sidebar.closed {
     width: 0;
     pointer-events: none;
     position: fixed;
-    left: -250px;
+    left: calc(var(--sidebar-width) * -1);
 }
 
 @media (min-width: 641px) {
+    :root {
+        --sidebar-width: 250px;
+    }
+
     .page {
         flex-direction: row;
     }
 
     .sidebar {
-        width: 250px;
         height: 100vh;
         position: sticky;
         top: 0;

--- a/PuzzleAM/Components/Shared/Tab.razor.css
+++ b/PuzzleAM/Components/Shared/Tab.razor.css
@@ -15,15 +15,16 @@
 .nav-tab {
     position: fixed;
     top: 1rem;
-    transition: left 0.3s ease;
+    left: 0;
+    transition: transform 0.3s ease;
     z-index: 2000;
     pointer-events: auto;
 }
 
 .nav-tab.open {
-    left: 250px;
+    transform: translateX(calc(var(--sidebar-width) - 100%));
 }
 
 .nav-tab.closed {
-    left: 0;
+    transform: translateX(0);
 }


### PR DESCRIPTION
## Summary
- add a CSS custom property that controls the sidebar width and reuse it for the closed offset
- update the navigation tab styles to align with the sidebar edge on all breakpoints

## Testing
- dotnet build PuzzleAM.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d9825fe3e883209831bcafaa1998c1