### PR TITLE
Ensure sidebar width variable is globally scoped

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -1,4 +1,4 @@
-:root {
+:global(:root) {
     --sidebar-width: 100vw;
 }
 
@@ -27,7 +27,7 @@ main {
 }
 
 @media (min-width: 641px) {
-    :root {
+    :global(:root) {
         --sidebar-width: 250px;
     }
 


### PR DESCRIPTION
## Summary
- expose the --sidebar-width custom property to the global :root so isolated styles can consume it
- keep the desktop override available globally within the media query

## Testing
- `dotnet build PuzzleAM.sln` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d983a882d08320baecdd37774a8825