### PR TITLE
Ensure puzzle panels respect viewport width

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -69,6 +69,36 @@ window.registerPuzzleEventHandler = function (dotNetHelper) {
     puzzleEventHandler = dotNetHelper;
 };
 
+let viewportResizeHandler;
+window.registerViewportResizeHandler = function (dotNetHelper) {
+    if (viewportResizeHandler) {
+        window.removeEventListener('resize', viewportResizeHandler);
+    }
+
+    viewportResizeHandler = () => {
+        if (!dotNetHelper) {
+            return;
+        }
+
+        try {
+            dotNetHelper.invokeMethodAsync('OnViewportResize', window.innerWidth || 0);
+        } catch (err) {
+            console.error('Error notifying viewport resize handler', err);
+        }
+    };
+
+    window.addEventListener('resize', viewportResizeHandler);
+};
+
+window.disposeViewportResizeHandler = function () {
+    if (!viewportResizeHandler) {
+        return;
+    }
+
+    window.removeEventListener('resize', viewportResizeHandler);
+    viewportResizeHandler = null;
+};
+
 function notifyPuzzleLoading(isLoading) {
     if (!puzzleEventHandler) {
         return;


### PR DESCRIPTION
## Summary
- prevent both the settings and user list panels from remaining open together on narrow viewports
- reuse a shared viewport width helper and hook a resize listener so shrink events enforce the same rule

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9864f36d083208e1e0d260021e4eb