### PR TITLE
Add configurable EF Core provider support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR /app
 
 # Expose port 8080 and configure Kestrel to listen on all interfaces
 EXPOSE 8080
-ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_URLS=http://+:8080 \
+    Database__Provider=Sqlite
 
 # Copy published output and start the application
 COPY --from=build /app/out .

--- a/PuzzleAM/PuzzleAM.csproj
+++ b/PuzzleAM/PuzzleAM.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/PuzzleAM/appsettings.Development.json
+++ b/PuzzleAM/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Database": {
+    "Provider": "Sqlite"
   }
 }

--- a/PuzzleAM/appsettings.json
+++ b/PuzzleAM/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Database": {
+    "Provider": "Sqlite"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=app.db"
   }

--- a/README.md
+++ b/README.md
@@ -12,3 +12,37 @@ This project uses [Heroicons](https://heroicons.com/) for navigation icons.
    ```
 
 Icons are sized automatically in the navigation menu via CSS. Adjust styles as needed for other locations.
+
+## Database configuration
+
+The application supports multiple Entity Framework Core providers. By default it runs against a local SQLite file, but you can
+change the provider and connection string without modifying the code.
+
+1. Set the provider name in configuration using the `Database:Provider` key. For JSON files this looks like:
+
+   ```json
+   {
+     "Database": {
+       "Provider": "Sqlite"
+     },
+     "ConnectionStrings": {
+       "DefaultConnection": "Data Source=app.db"
+     }
+   }
+   ```
+
+2. When deploying, provide the same settings through environment variables. For example:
+
+   ```bash
+   export Database__Provider=Npgsql
+   export ConnectionStrings__DefaultConnection="Host=localhost;Database=puzzledb;Username=postgres;Password=secret"
+   ```
+
+3. Supported provider values are:
+
+   - `Sqlite` (default) – stores data in a SQLite database file. The application will create a per-user data directory when needed.
+   - `Postgres`, `PostgreSQL`, or `Npgsql` – uses the Npgsql Entity Framework Core provider to connect to PostgreSQL-compatible
+     databases such as Cloud SQL for PostgreSQL.
+
+After updating configuration, run `dotnet ef database update` (or restart the application) to ensure migrations are applied to
+the configured database.


### PR DESCRIPTION
## Summary
- add configuration-based database provider selection in Program.cs
- include the Npgsql Entity Framework Core provider package and default provider environment variable
- document database configuration and provider options in the README

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9906da3d48320be04c212438951f4