### PR TITLE
Clear SQLite connection pool before deleting database file

### DIFF
--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -187,6 +187,8 @@ using (var scope = app.Services.CreateScope())
                             connection.Close();
                         }
 
+                        SqliteConnection.ClearPool(sqliteConnection);
+
                         if (File.Exists(databasePath))
                         {
                             File.Delete(databasePath);


### PR DESCRIPTION
## Summary
- clear the SQLite connection pool before deleting the database file to avoid file locks during rebuild

## Testing
- dotnet build *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ba2888f48320b1a687f66a1227f4