### PR TITLE
Add validation for SQLite connection strings and cover with tests

### DIFF
--- a/PuzzleAM.Tests/DatabaseProviderValidationTests.cs
+++ b/PuzzleAM.Tests/DatabaseProviderValidationTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+using PuzzleAM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace PuzzleAM.Tests;
+
+public class DatabaseProviderValidationTests
+{
+    [Fact]
+    public void ValidateAndNormalizeConnectionString_ThrowsForPostgresConnectionString()
+    {
+        const string provider = "Sqlite";
+        const string connectionString = "Host=localhost;Port=5432;Database=puzzleam;Username=postgres;Password=secret";
+        var logger = new TestLogger();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => SqliteConfigurationValidator.ValidateAndNormalizeConnectionString(connectionString, provider, logger));
+
+        Assert.Contains("Database:Provider", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(provider, exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        var logEntry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, logEntry.LogLevel);
+        Assert.Contains(provider, logEntry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Host=localhost", logEntry.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class TestLogger : ILogger
+    {
+        public List<TestLogEntry> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new TestLogEntry(logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    public sealed record TestLogEntry(LogLevel LogLevel, string Message);
+}

--- a/PuzzleAM.Tests/PuzzleAM.Tests.csproj
+++ b/PuzzleAM.Tests/PuzzleAM.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PuzzleAM\PuzzleAM.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PuzzleAM.sln
+++ b/PuzzleAM.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PuzzleAM.View", "PuzzleAM.V
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PuzzleAM.ViewServices", "PuzzleAM.ViewServices\PuzzleAM.ViewServices.csproj", "{B6CDA631-9833-4E8E-BA68-A14609C08936}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PuzzleAM.Tests", "PuzzleAM.Tests\PuzzleAM.Tests.csproj", "{D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -67,9 +69,21 @@ Global
 		{B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x64.ActiveCfg = Release|Any CPU
 		{B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x64.Build.0 = Release|Any CPU
-		{B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x86.ActiveCfg = Release|Any CPU
-		{B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x86.ActiveCfg = Release|Any CPU
+                {B6CDA631-9833-4E8E-BA68-A14609C08936}.Release|x86.Build.0 = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|x64.Build.0 = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Debug|x86.Build.0 = Debug|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|x64.ActiveCfg = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|x64.Build.0 = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|x86.ActiveCfg = Release|Any CPU
+                {D3C67B8E-7F0D-4F3C-93B3-E308AF9E871C}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/PuzzleAM/PuzzleAM.csproj
+++ b/PuzzleAM/PuzzleAM.csproj
@@ -25,4 +25,8 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="PuzzleAM.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/PuzzleAM/SqliteConfigurationValidator.cs
+++ b/PuzzleAM/SqliteConfigurationValidator.cs
@@ -1,0 +1,79 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace PuzzleAM;
+
+internal static class SqliteConfigurationValidator
+{
+    private static readonly string[] NonSqliteTokens =
+    [
+        "Host=",
+        "Server=",
+        "Username=",
+        "User Id=",
+        "UserId=",
+        "Password=",
+        "Port=",
+        "Ssl Mode=",
+        "SSL Mode=",
+        "Integrated Security=",
+        "Database="
+    ];
+
+    internal static string ValidateAndNormalizeConnectionString(string connectionString, string databaseProvider, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(connectionString);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (LooksLikeNonSqliteConnectionString(connectionString))
+        {
+            var message =
+                $"The configured database provider '{databaseProvider}' expects a SQLite connection string, but the supplied value appears to target a different database engine. Set 'Database:Provider' to 'Postgres' or provide a valid SQLite connection string.";
+            logger.LogError(
+                "{Message} Provider={Provider}; ConnectionString={ConnectionString}",
+                message,
+                databaseProvider,
+                connectionString);
+            throw new InvalidOperationException(message);
+        }
+
+        try
+        {
+            var sqliteBuilder = new SqliteConnectionStringBuilder(connectionString);
+            if (!Path.IsPathRooted(sqliteBuilder.DataSource))
+            {
+                var defaultDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PuzzleAM");
+                Directory.CreateDirectory(defaultDataDirectory);
+                sqliteBuilder.DataSource = Path.Combine(defaultDataDirectory, Path.GetFileName(sqliteBuilder.DataSource));
+            }
+
+            var dataDirectory = Path.GetDirectoryName(sqliteBuilder.DataSource);
+            if (!string.IsNullOrEmpty(dataDirectory))
+            {
+                Directory.CreateDirectory(dataDirectory);
+            }
+
+            return sqliteBuilder.ConnectionString;
+        }
+        catch (ArgumentException ex)
+        {
+            var message =
+                $"The configured database provider '{databaseProvider}' expects a valid SQLite connection string, but parsing the supplied value failed. Update 'Database:Provider' or correct the connection string.";
+            logger.LogError(
+                ex,
+                "{Message} Provider={Provider}; ConnectionString={ConnectionString}",
+                message,
+                databaseProvider,
+                connectionString);
+            throw new InvalidOperationException(message, ex);
+        }
+    }
+
+    private static bool LooksLikeNonSqliteConnectionString(string connectionString)
+    {
+        return NonSqliteTokens.Any(token => connectionString.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+}


### PR DESCRIPTION
## Summary
- validate SQLite connection strings before configuring the DbContext so mismatched providers log an error and fail fast
- extract validation and normalization into a shared helper that preserves the existing SQLite file handling
- add a test project with coverage for PostgreSQL-style connection strings hitting the new validation path

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9c3ec45188320808694480367c67e