### PR TITLE
Respect platform port configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ RUN dotnet publish -c Release -o /app/out
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app
 
-# Expose port 8080 and configure Kestrel to listen on all interfaces
+# Expose port 8080 and configure the default database provider
 EXPOSE 8080
-ENV ASPNETCORE_URLS=http://+:8080 \
-    Database__Provider=Sqlite
+ENV Database__Provider=Sqlite
 
-# Copy published output and start the application
+# Copy published output and the entrypoint script
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
 COPY --from=build /app/out .
-ENTRYPOINT ["dotnet", "PuzzleAM.dll"]
+
+# Run the application through the entrypoint script so it respects the PORT environment variable
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ change the provider and connection string without modifying the code.
 
 After updating configuration, run `dotnet ef database update` (or restart the application) to ensure migrations are applied to
 the configured database.
+
+## Container deployment
+
+The Docker image now reads the `PORT` environment variable when starting the application. Most platforms (including Cloud Run,
+Render, and Heroku-style services) inject this variable automatically. When `PORT` is not set the container listens on
+`8080`, matching the Dockerfile's exposed port. You no longer need to override `ASPNETCORE_URLS` manually; instead set
+`PORT` if your hosting environment requires a different listener port.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+PORT="${PORT:-8080}"
+
+exec dotnet PuzzleAM.dll --urls "http://0.0.0.0:${PORT}"


### PR DESCRIPTION
## Summary
- add a lightweight entrypoint script that maps the PORT environment variable to the application's listening URL
- update the Dockerfile to use the entrypoint script and drop the hard-coded ASPNETCORE_URLS
- document the new container behaviour in the deployment instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c3eba39c8320a53487a186ca9622