### PR TITLE
Include test project in Docker restore stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY PuzzleAM/*.csproj PuzzleAM/
 COPY PuzzleAM.Model/*.csproj PuzzleAM.Model/
 COPY PuzzleAM.View/*.csproj PuzzleAM.View/
 COPY PuzzleAM.ViewServices/*.csproj PuzzleAM.ViewServices/
+COPY PuzzleAM.Tests/*.csproj PuzzleAM.Tests/
 RUN dotnet restore PuzzleAM.sln
 
 # Copy the rest of the source and publish


### PR DESCRIPTION
## Summary
- copy the PuzzleAM.Tests project file in the Docker build context so `dotnet restore` can resolve it

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9c71f36508320a6e0b5b416d15401