### PR TITLE
Update logging abstraction dependency to 8.0.1

### DIFF
--- a/PuzzleAM.Tests/PuzzleAM.Tests.csproj
+++ b/PuzzleAM.Tests/PuzzleAM.Tests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- bump Microsoft.Extensions.Logging.Abstractions in PuzzleAM.Tests to version 8.0.1 to satisfy dependency requirements during restore

## Testing
- dotnet restore PuzzleAM.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c8ec1c3c83209ce4a9f5dd4e23a2