### PR TITLE
Handle SQLite data directory fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ change the provider and connection string without modifying the code.
 3. Supported provider values are:
 
    - `Sqlite` (default) – stores data in a SQLite database file. The application will create a per-user data directory when needed.
+     If it cannot create that directory (for example, due to read-only storage), the database file falls back to
+     `%TEMP%/PuzzleAM/<database file>` so it can still operate in environments with limited permissions.
    - `Postgres`, `PostgreSQL`, or `Npgsql` – uses the Npgsql Entity Framework Core provider to connect to PostgreSQL-compatible
      databases such as Cloud SQL for PostgreSQL.
 


### PR DESCRIPTION
## Summary
- guard SQLite data directory creation and automatically fall back to a writable temp path when the default directories are not available
- expose a test hook for directory creation and add a unit test that verifies the fallback connection string
- document the SQLite fallback location for operators

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9cdd934148320b365b22e01c99564