### PR TITLE
Limit SQLite temp fallback to relative data sources

### DIFF
--- a/PuzzleAM.Tests/DatabaseProviderValidationTests.cs
+++ b/PuzzleAM.Tests/DatabaseProviderValidationTests.cs
@@ -28,6 +28,22 @@ public class DatabaseProviderValidationTests
         Assert.Contains("Host=localhost", logEntry.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void ValidateAndNormalizeConnectionString_ThrowsWhenAbsolutePathCannotBeEnsured()
+    {
+        const string provider = "Sqlite";
+        const string connectionString = "Data Source=/dev/null/puzzleam.db";
+        var logger = new TestLogger();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => SqliteConfigurationValidator.ValidateAndNormalizeConnectionString(connectionString, provider, logger));
+
+        Assert.Contains("/dev/null", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        var errorLog = Assert.Single(logger.Entries.Where(entry => entry.LogLevel == LogLevel.Error));
+        Assert.Contains("/dev/null", errorLog.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private sealed class TestLogger : ILogger
     {
         public List<TestLogEntry> Entries { get; } = new();

--- a/PuzzleAM/SqliteConfigurationValidator.cs
+++ b/PuzzleAM/SqliteConfigurationValidator.cs
@@ -43,17 +43,19 @@ internal static class SqliteConfigurationValidator
         try
         {
             var sqliteBuilder = new SqliteConnectionStringBuilder(connectionString);
-            if (!Path.IsPathRooted(sqliteBuilder.DataSource))
-            {
-                var defaultDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PuzzleAM");
-                Directory.CreateDirectory(defaultDataDirectory);
-                sqliteBuilder.DataSource = Path.Combine(defaultDataDirectory, Path.GetFileName(sqliteBuilder.DataSource));
-            }
+            var originalDataSource = sqliteBuilder.DataSource;
 
-            var dataDirectory = Path.GetDirectoryName(sqliteBuilder.DataSource);
-            if (!string.IsNullOrEmpty(dataDirectory))
+            if (!string.Equals(originalDataSource, ":memory:", StringComparison.OrdinalIgnoreCase))
             {
-                Directory.CreateDirectory(dataDirectory);
+                if (!Path.IsPathRooted(originalDataSource))
+                {
+                    var dataDirectory = EnsureDefaultDataDirectory(logger, connectionString, databaseProvider);
+                    sqliteBuilder.DataSource = Path.Combine(dataDirectory, Path.GetFileName(originalDataSource));
+                }
+                else
+                {
+                    EnsureExplicitDataDirectory(originalDataSource, logger, connectionString, databaseProvider);
+                }
             }
 
             return sqliteBuilder.ConnectionString;
@@ -75,5 +77,85 @@ internal static class SqliteConfigurationValidator
     private static bool LooksLikeNonSqliteConnectionString(string connectionString)
     {
         return NonSqliteTokens.Any(token => connectionString.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private static string EnsureDefaultDataDirectory(ILogger logger, string connectionString, string databaseProvider)
+    {
+        var defaultDataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PuzzleAM");
+
+        if (TryEnsureDirectory(defaultDataDirectory, out var creationError))
+        {
+            return defaultDataDirectory;
+        }
+
+        var fallbackDataDirectory = Path.Combine(Path.GetTempPath(), "PuzzleAM");
+        if (TryEnsureDirectory(fallbackDataDirectory, out var fallbackError))
+        {
+            logger.LogWarning(
+                creationError,
+                "Falling back to temporary data directory {FallbackDirectory} after failing to ensure {DefaultDirectory}. Provider={Provider}; ConnectionString={ConnectionString}",
+                fallbackDataDirectory,
+                defaultDataDirectory,
+                databaseProvider,
+                connectionString);
+            return fallbackDataDirectory;
+        }
+
+        var message =
+            $"The configured database provider '{databaseProvider}' could not ensure a writable directory for the SQLite data source. Review the connection string and file system permissions.";
+        var failure = fallbackError ?? creationError!;
+        logger.LogError(
+            failure,
+            "{Message} Provider={Provider}; ConnectionString={ConnectionString}",
+            message,
+            databaseProvider,
+            connectionString);
+        throw new InvalidOperationException(message, failure);
+    }
+
+    private static void EnsureExplicitDataDirectory(string dataSource, ILogger logger, string connectionString, string databaseProvider)
+    {
+        var dataDirectory = Path.GetDirectoryName(dataSource);
+        if (string.IsNullOrEmpty(dataDirectory))
+        {
+            return;
+        }
+
+        if (TryEnsureDirectory(dataDirectory, out var exception))
+        {
+            return;
+        }
+
+        var message =
+            $"The configured SQLite data directory '{dataDirectory}' for provider '{databaseProvider}' could not be created or accessed. Adjust the connection string or fix the directory permissions.";
+        logger.LogError(
+            exception,
+            "{Message} Provider={Provider}; ConnectionString={ConnectionString}; DataDirectory={DataDirectory}",
+            message,
+            databaseProvider,
+            connectionString,
+            dataDirectory);
+        throw new InvalidOperationException(message, exception);
+    }
+
+    private static bool TryEnsureDirectory(string? directory, out Exception? exception)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(directory))
+            {
+                exception = null;
+                return true;
+            }
+
+            Directory.CreateDirectory(directory);
+            exception = null;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException or System.Security.SecurityException or DirectoryNotFoundException)
+        {
+            exception = ex;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the SQLite connection string normalizer only falls back to the temp directory when the data source is relative
- surface failures for explicit absolute data directories with detailed logging instead of silently redirecting
- add a regression test that verifies an invalid absolute path still throws

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd729f046c832082814e9e1640b6c6