### PR TITLE
Improve registration feedback messages

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -145,11 +145,12 @@
         if (registerModel.Password != registerModel.ConfirmPassword)
         {
             registerError = "Passwords do not match";
+            registerMessage = null;
             return;
         }
         var token = Antiforgery.GetAntiforgeryToken();
-        var success = await JS.InvokeAsync<bool>("register", token.Value, registerModel);
-        if (success)
+        var result = await JS.InvokeAsync<RegisterResult>("register", token.Value, registerModel);
+        if (result.Success)
         {
             registerError = null;
             registerMessage = "Account created successfully";
@@ -158,7 +159,9 @@
         }
         else
         {
-            registerError = "Registration failed";
+            registerError = string.IsNullOrWhiteSpace(result.Error)
+                ? "Registration failed"
+                : result.Error;
             registerMessage = null;
         }
     }
@@ -195,6 +198,12 @@
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public string ConfirmPassword { get; set; } = string.Empty;
+    }
+
+    public class RegisterResult
+    {
+        public bool Success { get; set; }
+        public string? Error { get; set; }
     }
 
     public class LoginModel

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -453,16 +453,19 @@ app.MapPost("/register", async (UserManager<IdentityUser> userManager, SignInMan
 {
     if (req.Password != req.ConfirmPassword)
     {
-        return Results.BadRequest("Passwords do not match");
+        return Results.BadRequest(new { message = "Passwords do not match" });
     }
+
     var user = new IdentityUser(req.Username);
     var result = await userManager.CreateAsync(user, req.Password);
     if (!result.Succeeded)
     {
-        return Results.BadRequest(result.Errors);
+        var message = string.Join(" ", result.Errors.Select(e => e.Description));
+        return Results.BadRequest(new { message });
     }
+
     await signInManager.SignInAsync(user, isPersistent: false);
-    return Results.Ok();
+    return Results.Ok(new { message = "Account created successfully" });
 });
 
 app.MapPost("/login", async (SignInManager<IdentityUser> signInManager, LoginRequest req) =>

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1171,7 +1171,26 @@ window.register = async function (token, model) {
         body: JSON.stringify(model),
         credentials: 'include'
     });
-    return response.ok;
+
+    if (response.ok) {
+        return { success: true };
+    }
+
+    let error = 'Registration failed';
+    try {
+        const data = await response.json();
+        if (typeof data === 'string') {
+            error = data;
+        } else if (data?.message) {
+            error = data.message;
+        } else if (Array.isArray(data?.errors) && data.errors.length > 0) {
+            error = data.errors.join(' ');
+        }
+    } catch {
+        // Ignore JSON parse errors and use the default message
+    }
+
+    return { success: false, error };
 };
 
 window.login = async function (token, model) {


### PR DESCRIPTION
## Summary
- return descriptive error details from the registration endpoint
- propagate registration failure reasons to the client and display them in the UI

## Testing
- dotnet test *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda6d53a5083208211626d92b4427c