### PR TITLE
Ensure HttpContextAccessor is registered for authentication

### DIFF
--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -42,6 +42,8 @@ var sqliteValidationLock = new object();
 var sqliteConfigurationValidated = false;
 string? normalizedSqliteConnectionString = null;
 
+builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =>
 {
     if (string.Equals(databaseProvider, "Sqlite", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
## Summary
- register the IHttpContextAccessor service so SignInManager can operate without throwing

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddab4f9eac8320a6002720e4f5be2f