### PR TITLE
Improve login error handling

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -169,8 +169,8 @@
     private async Task Login()
     {
         var token = Antiforgery.GetAntiforgeryToken();
-        var success = await JS.InvokeAsync<bool>("login", token.Value, loginModel);
-        if (success)
+        var result = await JS.InvokeAsync<LoginResult>("login", token.Value, loginModel);
+        if (result.Success)
         {
             loginError = null;
             currentUsername = loginModel.Username;
@@ -178,7 +178,9 @@
         }
         else
         {
-            loginError = "Login failed";
+            loginError = string.IsNullOrWhiteSpace(result.Error)
+                ? "Login failed"
+                : result.Error;
         }
     }
 
@@ -210,5 +212,11 @@
     {
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
+    }
+
+    public class LoginResult
+    {
+        public bool Success { get; set; }
+        public string? Error { get; set; }
     }
 }

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -1203,7 +1203,24 @@ window.login = async function (token, model) {
         body: JSON.stringify(model),
         credentials: 'include'
     });
-    return response.ok;
+
+    if (response.ok) {
+        return { success: true };
+    }
+
+    let error = 'Login failed';
+    try {
+        const data = await response.json();
+        if (typeof data === 'string') {
+            error = data;
+        } else if (data?.message) {
+            error = data.message;
+        }
+    } catch {
+        // Ignore JSON parse errors and use the default message
+    }
+
+    return { success: false, error };
 };
 
 window.logout = async function (token) {


### PR DESCRIPTION
## Summary
- update the login helper to return detailed errors on failed responses
- consume the detailed login result in Home.razor and surface specific error messages in the modal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb0af58bc8320964f77129e1731c1