### PR TITLE
Allow configuring database provider in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ WORKDIR /app
 
 # Expose port 8080 and configure the default database provider
 EXPOSE 8080
-ENV Database__Provider=Sqlite
+ARG DATABASE_PROVIDER=Sqlite
+ENV Database__Provider=$DATABASE_PROVIDER
 
 # Copy published output and the entrypoint script
 COPY docker-entrypoint.sh ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,34 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - build
+      - '-t'
+      - '${_IMAGE}'
+      - '--build-arg'
+      - 'DATABASE_PROVIDER=${_DATABASE_PROVIDER}'
+      - '.'
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - push
+      - '${_IMAGE}'
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - run
+      - deploy
+      - '${_SERVICE_NAME}'
+      - '--image'
+      - '${_IMAGE}'
+      - '--region'
+      - '${_REGION}'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--set-env-vars'
+      - >-
+        Database__Provider=${_DATABASE_PROVIDER},ConnectionStrings__DefaultConnection=${_CONNECTION_STRING}
+substitutions:
+  _IMAGE: gcr.io/$PROJECT_ID/puzzleam
+  _SERVICE_NAME: puzzleam
+  _REGION: us-central1
+  _DATABASE_PROVIDER: Postgres
+  _CONNECTION_STRING: Host=/cloudsql/PROJECT:REGION:INSTANCE;Database=puzzledb;Username=postgres;Password=CHANGE_ME


### PR DESCRIPTION
## Summary
- allow overriding the runtime database provider in the Docker image via a DATABASE_PROVIDER build argument
- add a Cloud Build configuration that builds with PostgreSQL and deploys with the appropriate environment variables
- document the Cloud Build and Cloud Run environment settings required for PostgreSQL deployments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb9b7f8208320b93b824a2d141950