### PR TITLE
Add Cloud SQL instance binding to Cloud Run deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,8 @@ steps:
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'
+      - '--add-cloudsql-instances'
+      - '${_CLOUDSQL_INSTANCE}'
       - '--set-env-vars'
       - >-
         Database__Provider=${_DATABASE_PROVIDER},ConnectionStrings__DefaultConnection=${_CONNECTION_STRING}
@@ -32,3 +34,4 @@ substitutions:
   _REGION: us-central1
   _DATABASE_PROVIDER: Postgres
   _CONNECTION_STRING: Host=/cloudsql/PROJECT:REGION:INSTANCE;Database=puzzledb;Username=postgres;Password=CHANGE_ME
+  _CLOUDSQL_INSTANCE: PROJECT:REGION:INSTANCE


### PR DESCRIPTION
## Summary
- ensure Cloud Run deployment mounts the Cloud SQL Unix-domain socket by passing --add-cloudsql-instances
- provide a substitution for the Cloud SQL instance connection name used by the deploy step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddbf90a5d083208640c7b4de90c654