### PR TITLE
Display database provider information on home page

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JS
 @inject NavigationManager Nav
 @inject AntiforgeryStateProvider Antiforgery
+@inject DatabaseProviderInfo DatabaseProviderInfo
 @using Microsoft.AspNetCore.Components.Forms
 
 <div class="position-absolute top-0 end-0 p-3 d-flex align-items-center pe-none">
@@ -36,6 +37,7 @@
     {
         <div class="text-danger">@errorMessage</div>
     }
+    <div class="mt-3 text-muted">Currently using @DatabaseProviderInfo.ProviderDescription.</div>
 </div>
 
 <div class="modal fade" id="registerModal" tabindex="-1">

--- a/PuzzleAM/DatabaseProviderInfo.cs
+++ b/PuzzleAM/DatabaseProviderInfo.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace PuzzleAM;
+
+public sealed class DatabaseProviderInfo
+{
+    public DatabaseProviderInfo(string configuredProvider)
+    {
+        ConfiguredProvider = configuredProvider;
+        ProviderDisplayName = NormalizeProviderName(configuredProvider);
+    }
+
+    public string ConfiguredProvider { get; }
+
+    public string ProviderDisplayName { get; }
+
+    public string ProviderDescription => ProviderDisplayName switch
+    {
+        "SQLite" => "SQLite database",
+        "PostgreSQL" => "PostgreSQL database",
+        _ => $"{ProviderDisplayName} database"
+    };
+
+    private static string NormalizeProviderName(string configuredProvider)
+    {
+        if (string.IsNullOrWhiteSpace(configuredProvider))
+        {
+            return "SQLite";
+        }
+
+        if (string.Equals(configuredProvider, "Sqlite", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(configuredProvider, "Microsoft.Data.Sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            return "SQLite";
+        }
+
+        if (string.Equals(configuredProvider, "Postgres", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(configuredProvider, "PostgreSQL", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(configuredProvider, "Npgsql", StringComparison.OrdinalIgnoreCase))
+        {
+            return "PostgreSQL";
+        }
+
+        return configuredProvider;
+    }
+}

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -38,6 +38,8 @@ builder.Services.AddScoped(sp => new HttpClient
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=app.db";
 var databaseProvider = builder.Configuration["Database:Provider"] ?? "Sqlite";
 
+builder.Services.AddSingleton(new DatabaseProviderInfo(databaseProvider));
+
 var sqliteValidationLock = new object();
 var sqliteConfigurationValidated = false;
 string? normalizedSqliteConnectionString = null;


### PR DESCRIPTION
## Summary
- add a DatabaseProviderInfo service to normalize the configured provider name
- display the current database provider on the home page so users can see whether SQLite or PostgreSQL is active

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc57f4a3083208b267277ea3143da