### PR TITLE
Support DATABASE_PROVIDER fallback for production deployments

### DIFF
--- a/PuzzleAM.Tests/DatabaseConfigurationTests.cs
+++ b/PuzzleAM.Tests/DatabaseConfigurationTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Configuration;
+using PuzzleAM;
+using System.Collections.Generic;
+using Xunit;
+
+namespace PuzzleAM.Tests;
+
+public class DatabaseConfigurationTests
+{
+    [Fact]
+    public void GetDatabaseProvider_UsesDatabaseProviderSetting()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:Provider"] = "Postgres"
+        });
+
+        var provider = DatabaseConfiguration.GetDatabaseProvider(configuration);
+
+        Assert.Equal("Postgres", provider);
+    }
+
+    [Fact]
+    public void GetDatabaseProvider_FallsBackToEnvironmentVariableStyleKey()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["DATABASE_PROVIDER"] = "Postgres"
+        });
+
+        var provider = DatabaseConfiguration.GetDatabaseProvider(configuration);
+
+        Assert.Equal("Postgres", provider);
+    }
+
+    [Fact]
+    public void GetDatabaseProvider_DefaultsToSqlite()
+    {
+        var configuration = BuildConfiguration();
+
+        var provider = DatabaseConfiguration.GetDatabaseProvider(configuration);
+
+        Assert.Equal("Sqlite", provider);
+    }
+
+    [Fact]
+    public void GetConnectionString_UsesConfiguredConnectionString()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = "Host=/cloudsql/example" 
+        });
+
+        var connectionString = DatabaseConfiguration.GetConnectionString(configuration);
+
+        Assert.Equal("Host=/cloudsql/example", connectionString);
+    }
+
+    [Fact]
+    public void GetConnectionString_FallsBackToEnvironmentVariableStyleKey()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["DATABASE_CONNECTION_STRING"] = "Host=/cloudsql/example"
+        });
+
+        var connectionString = DatabaseConfiguration.GetConnectionString(configuration);
+
+        Assert.Equal("Host=/cloudsql/example", connectionString);
+    }
+
+    [Fact]
+    public void GetConnectionString_DefaultsToSqliteFile()
+    {
+        var configuration = BuildConfiguration();
+
+        var connectionString = DatabaseConfiguration.GetConnectionString(configuration);
+
+        Assert.Equal("Data Source=app.db", connectionString);
+    }
+
+    private static IConfiguration BuildConfiguration(IDictionary<string, string?>? values = null)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values ?? new Dictionary<string, string?>())
+            .Build();
+    }
+}

--- a/PuzzleAM/DatabaseConfiguration.cs
+++ b/PuzzleAM/DatabaseConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace PuzzleAM;
+
+internal static class DatabaseConfiguration
+{
+    private const string DefaultProvider = "Sqlite";
+    private const string DatabaseProviderKey = "Database:Provider";
+    private const string DatabaseProviderEnvironmentFallbackKey = "DATABASE_PROVIDER";
+    private const string DefaultConnectionName = "DefaultConnection";
+    private const string ConnectionStringFallbackKey = "DATABASE_CONNECTION_STRING";
+
+    public static string GetDatabaseProvider(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var provider = configuration[DatabaseProviderKey];
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            provider = configuration[DatabaseProviderEnvironmentFallbackKey];
+        }
+
+        return string.IsNullOrWhiteSpace(provider) ? DefaultProvider : provider;
+    }
+
+    public static string GetConnectionString(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var connectionString = configuration.GetConnectionString(DefaultConnectionName);
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = configuration[ConnectionStringFallbackKey];
+        }
+
+        return string.IsNullOrWhiteSpace(connectionString)
+            ? "Data Source=app.db"
+            : connectionString;
+    }
+}

--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -35,8 +35,8 @@ builder.Services.AddScoped(sp => new HttpClient
         BaseAddress = new Uri(sp.GetRequiredService<NavigationManager>().BaseUri)
     });
 
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=app.db";
-var databaseProvider = builder.Configuration["Database:Provider"] ?? "Sqlite";
+var connectionString = DatabaseConfiguration.GetConnectionString(builder.Configuration);
+var databaseProvider = DatabaseConfiguration.GetDatabaseProvider(builder.Configuration);
 
 builder.Services.AddSingleton(new DatabaseProviderInfo(databaseProvider));
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ change the provider and connection string without modifying the code.
    export ConnectionStrings__DefaultConnection="Host=localhost;Database=puzzledb;Username=postgres;Password=secret"
    ```
 
+   The application also recognises simplified environment variables such as `DATABASE_PROVIDER` and
+   `DATABASE_CONNECTION_STRING`, which can be helpful on platforms that do not support hierarchical
+   configuration keys.
+
 3. Supported provider values are:
 
    - `Sqlite` (default) – stores data in a SQLite database file. The application will create a per-user data directory when needed.


### PR DESCRIPTION
## Summary
- add a configuration helper that falls back to DATABASE_PROVIDER and DATABASE_CONNECTION_STRING environment variables
- switch Program.cs to use the helper so Cloud Run deployments pick up PostgreSQL settings when provided this way
- document the simplified environment variables and add unit tests covering the new configuration behaviour

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ddc820566c8320b586a9b107b9e9b4