### PR TITLE
Set Docker runtime default database provider to Postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 # Expose port 8080 and configure the default database provider
 EXPOSE 8080
-ARG DATABASE_PROVIDER=Sqlite
+ARG DATABASE_PROVIDER=Postgres
 ENV Database__Provider=$DATABASE_PROVIDER
 
 # Copy published output and the entrypoint script


### PR DESCRIPTION
## Summary
- change the runtime-stage default DATABASE_PROVIDER build argument from Sqlite to Postgres so deployed images default to PostgreSQL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deaa504cbc83209e65a0765072a0ee