### PR TITLE
Document Postgres deployment configuration

### DIFF
--- a/PuzzleAM/appsettings.Production.json
+++ b/PuzzleAM/appsettings.Production.json
@@ -1,0 +1,8 @@
+{
+  "Database": {
+    "Provider": "Postgres"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=/cloudsql/PROJECT:REGION:INSTANCE;Database=puzzledb;Username=postgres;Password=CHANGE_ME"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ defaults to `Sqlite`, but setting it ensures production images contain the corre
 Build uses the `cloudbuild.yaml` file in this repository to build and deploy the image with PostgreSQL enabled:
 
 ```bash
-gcloud builds submit --config cloudbuild.yaml --substitutions _CONNECTION_STRING="Host=/cloudsql/PROJECT:REGION:INSTANCE;Database=puzzledb;Username=postgres;Password=CHANGE_ME"
+gcloud builds submit --config cloudbuild.yaml \ 
+  --substitutions _CONNECTION_STRING="Host=/cloudsql/PROJECT:REGION:INSTANCE;Database=puzzledb;Username=postgres;Password=CHANGE_ME"
 ```
+
+Update the `_CONNECTION_STRING` substitution with your actual Cloud SQL/PostgreSQL connection string before creating the
+Cloud Build trigger. After the trigger is created, verify in the Google Cloud console that the substitutions section still
+shows `_DATABASE_PROVIDER=Postgres` and your `_CONNECTION_STRING` value so those settings propagate to every build.
 
 The Cloud Build configuration passes `DATABASE_PROVIDER=Postgres` to `docker build` and deploys to Cloud Run with the
 following environment variables:
@@ -72,7 +77,9 @@ Database__Provider=Postgres
 ConnectionStrings__DefaultConnection=<your PostgreSQL connection string>
 ```
 
-If you deploy with `gcloud run deploy` manually, be sure to include the same environment variables:
+After Cloud Run finishes deploying, open the **Variables & Secrets** tab for the service and confirm that both of those
+environment variables are present. If you deploy with `gcloud run deploy` manually, be sure to include the same environment
+variables:
 
 ```bash
 gcloud run deploy puzzleam \


### PR DESCRIPTION
## Summary
- document how to update the Cloud Build trigger with the production PostgreSQL connection string and verify the resulting Cloud Run environment variables
- add a production appsettings file that defaults to the Postgres provider and Cloud SQL connection format to prevent falling back to SQLite

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deaa50d0f88320988538b5de85534d