### PR TITLE
Update production connection string password

### DIFF
--- a/PuzzleAM/appsettings.Production.json
+++ b/PuzzleAM/appsettings.Production.json
@@ -3,6 +3,6 @@
     "Provider": "Postgres"
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=/cloudsql/neural-geode-471217-d2:europe-west2:puzzle-db;Database=puzzle-db;Username=puzzle-db;Password=3ZGG\\d[U22hG~E%}"
+    "DefaultConnection": "Host=/cloudsql/neural-geode-471217-d2:europe-west2:puzzle-db;Database=puzzle-db;Username=puzzle-db;Password=3ZGG\\d[U22hG~E%"
   }
 }


### PR DESCRIPTION
## Summary
- remove the trailing brace from the production DefaultConnection string so the password ends with `3ZGG\d[U22hG~E%`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e035c9dc508320a4fa03780dce8b2a