### PR TITLE
Configure persistent data protection key storage

### DIFF
--- a/PuzzleAM/Program.cs
+++ b/PuzzleAM/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -80,6 +81,23 @@ builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =
         throw new InvalidOperationException($"Unsupported database provider '{databaseProvider}'.");
     }
 });
+var dataProtectionKeysPath = Environment.GetEnvironmentVariable("DATA_PROTECTION_KEYS_PATH");
+if (string.IsNullOrWhiteSpace(dataProtectionKeysPath))
+{
+    if (builder.Environment.IsDevelopment())
+    {
+        dataProtectionKeysPath = Path.Combine("/tmp", "aspnet-data-protection");
+    }
+    else
+    {
+        throw new InvalidOperationException("The DATA_PROTECTION_KEYS_PATH environment variable must be set to a shared directory in production environments.");
+    }
+}
+
+Directory.CreateDirectory(dataProtectionKeysPath);
+
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(dataProtectionKeysPath));
 builder.Services.AddIdentityCore<IdentityUser>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddSignInManager();


### PR DESCRIPTION
## Summary
- persist ASP.NET Core data protection keys to a configurable shared directory
- create the shared directory during startup and require configuration outside of development

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1013951d48320a8e8108943146cea