### PR TITLE
Add missing EF Core migration metadata

### DIFF
--- a/PuzzleAM/Migrations/20240909000000_InitialCreate.cs
+++ b/PuzzleAM/Migrations/20240909000000_InitialCreate.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -7,6 +8,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace PuzzleAM.Migrations
 {
     /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240909000000_InitialCreate")]
     public partial class InitialCreate : Migration
     {
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- add the DbContext and Migration attributes to the InitialCreate migration so EF Core can discover it at runtime

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e260e082f08320abcd19db3770c863