### PR TITLE
Update landing page title styling

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -25,7 +25,7 @@
     }
 </div>
 
-<h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
+<h1 class="text-center fw-bold mt-5 landing-title">PUZZLE AM</h1>
 <img src="images/AM_logo.png" alt="Puzzle AM logo" class="d-block mx-auto" style="width:20vw; filter: drop-shadow(rgba(0, 0, 0, 0.9) 0px 3px 10px);" />
 <div class="d-flex flex-column align-items-center mt-3">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Cool+Light+Text+Bubbles&display=swap');
+
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     height: 100%;
@@ -30,6 +32,10 @@ a, .btn-link {
 
 h1:focus {
     outline: none;
+}
+
+.landing-title {
+    font-family: 'Cool Light Text Bubbles', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 .valid.modified:not([type=checkbox]) {


### PR DESCRIPTION
## Summary
- update the landing page hero text to display "PUZZLE AM"
- load the Cool Light Text Bubbles font and apply it to the landing page title

## Testing
- unable to run `dotnet run --project PuzzleAM` (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2b963a06083209cf204bb542ba714