### PR TITLE
Update landing page title font

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -25,7 +25,7 @@
     }
 </div>
 
-<h1 class="text-center fw-bold mt-5 landing-title">PUZZLE AM</h1>
+<h1 class="text-center fw-bold mt-5 landing-title">ⓅⓊⓏⓏⓁⒺ ⒶⓂ</h1>
 <img src="images/AM_logo.png" alt="Puzzle AM logo" class="d-block mx-auto" style="width:20vw; filter: drop-shadow(rgba(0, 0, 0, 0.9) 0px 3px 10px);" />
 <div class="d-flex flex-column align-items-center mt-3">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>


### PR DESCRIPTION
## Summary
- replace the landing page heading text with the stylized “ⓅⓊⓏⓏⓁⒺ ⒶⓂ” variant so it renders in the bubble font

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2bc73eaa0832086172c8165a52af0