### PR TITLE
Persist puzzle piece tab orientations

### DIFF
--- a/PuzzleAM.Model/PuzzleState.cs
+++ b/PuzzleAM.Model/PuzzleState.cs
@@ -3,9 +3,18 @@ namespace PuzzleAM.Model;
 using System.Collections.Concurrent;
 
 /// <summary>
-/// Represents the position of a puzzle piece on the board.
+/// Represents the position of a puzzle piece on the board including its tab
+/// orientations.
 /// </summary>
-public record PiecePosition(int Id, float Left, float Top, int? GroupId);
+public record PiecePosition(
+    int Id,
+    float Left,
+    float Top,
+    int? GroupId,
+    int TopTab,
+    int RightTab,
+    int BottomTab,
+    int LeftTab);
 
 /// <summary>
 /// Maintains the current state of a puzzle session.


### PR DESCRIPTION
## Summary
- extend `PiecePosition` to track the four edge orientations and persist them with each room
- seed complementary tab directions when a puzzle is generated and include them in `BoardState`
- consume the supplied orientations on the client so reconnects reuse the same piece shapes

## Testing
- dotnet test *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c5ac86cc8320a9818b8e6b33558c