### PR TITLE
Improve mobile image upload resilience

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -119,7 +119,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         // Resize large images more aggressively so we transmit less data. Adjust the
         // maximum dimension based on the device width so smaller devices transmit
         // proportionally smaller images.
-        var deviceWidth = await JS.InvokeAsync<int>("eval", "window.innerWidth");
+        var deviceWidth = await GetDeviceWidthAsync();
         var maxDimension = deviceWidth < 576 ? 400
             : deviceWidth < 992 ? 600
             : 800;
@@ -180,6 +180,24 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         {
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private async Task<int> GetDeviceWidthAsync()
+    {
+        try
+        {
+            return await JS.InvokeAsync<int>("eval", "window.innerWidth");
+        }
+        catch (Exception ex) when (IsDisconnectedException(ex))
+        {
+            Logger.LogInformation(ex, "Falling back to default device width while the JS runtime reconnects.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Unable to determine device width; using fallback value.");
+        }
+
+        return 768;
     }
 
     private async Task CopyRoomCode()
@@ -480,7 +498,7 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     {
         try
         {
-            await Task.Delay(TimeSpan.FromSeconds(5), token);
+            await Task.Delay(TimeSpan.FromSeconds(2), token);
         }
         catch (TaskCanceledException)
         {

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -151,7 +151,7 @@ function playApplauseSound() {
 async function startHubConnection() {
     hubConnection = new signalR.HubConnectionBuilder()
         .withUrl("/puzzlehub")
-        .withAutomaticReconnect()
+        .withAutomaticReconnect([0, 2, 5, 10])
         .build();
 
     window.puzzleHub = hubConnection;
@@ -358,6 +358,17 @@ async function releasePieceLock(pieceIds) {
 
 // Start the SignalR connection immediately instead of waiting for the window load event
 let connectionPromise = startHubConnection();
+
+function resumeHubConnectionIfNeeded() {
+    if (document.hidden) {
+        return;
+    }
+
+    ensureHubConnection();
+}
+
+window.addEventListener('visibilitychange', resumeHubConnectionIfNeeded);
+window.addEventListener('focus', resumeHubConnectionIfNeeded);
 
 async function ensureHubConnection() {
     if (!connectionPromise || !hubConnection ||


### PR DESCRIPTION
## Summary
- allow puzzle uploads to proceed when the JS runtime is reconnecting by falling back to a default device width
- retry pending puzzle uploads more quickly after transient disconnects
- prompt the SignalR hub to reconnect sooner on mobile by tuning reconnect intervals and resuming on focus/visibility changes

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c875a648320a4605b07d83dec10