### PR TITLE
Restore connect sound behavior and gate start sound

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -12,9 +12,9 @@ let currentRoomCode = null;
 const locallyMovedPieces = new Set();
 // Flag to ensure puzzle completion is only processed once
 window.puzzleCompleted = false;
-// Track whether the connect and applause sounds have already been played for the
+// Track whether the start and applause sounds have already been played for the
 // current puzzle so resize/orientation changes do not replay them.
-window.connectSoundPlayed = false;
+window.startSoundPlayed = false;
 window.applauseSoundPlayed = false;
 
 // Persist the current puzzle layout and image so it can be recreated later
@@ -126,6 +126,10 @@ function isMobileDevice() {
 }
 
 function playStartSound() {
+    if (window.startSoundPlayed) {
+        return;
+    }
+    window.startSoundPlayed = true;
     try {
         sounds.start.currentTime = 0;
         sounds.start.play();
@@ -135,10 +139,6 @@ function playStartSound() {
 }
 
 function playConnectSound() {
-    if (window.connectSoundPlayed) {
-        return;
-    }
-    window.connectSoundPlayed = true;
     try {
         sounds.connect.currentTime = 0;
         sounds.connect.play();
@@ -421,7 +421,7 @@ window.resetPuzzleState = function () {
     window.maxZ = 1;
     window.workspaceOffset = 0;
     window.puzzleCompleted = false;
-    window.connectSoundPlayed = false;
+    window.startSoundPlayed = false;
     window.applauseSoundPlayed = false;
     window.currentLayout = null;
     window.currentImageDataUrl = null;
@@ -921,9 +921,6 @@ window.createPuzzle = async function (imageDataUrl, containerId, layout) {
                 } else if (currentGeneration === window.puzzleGeneration) {
                     updateAllShadows();
                     playStartSound();
-                    if (!window.connectSoundPlayed) {
-                        playConnectSound();
-                    }
                     notifyPuzzleLoading(false);
                     if (puzzleEventHandler) {
                         puzzleEventHandler.invokeMethodAsync('PuzzleLoaded');


### PR DESCRIPTION
## Summary
- allow the connect sound effect to play every time pieces snap together
- ensure the start sound effect only plays once per puzzle load
- reset the start sound state when leaving or joining a puzzle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6ace7d3648320b83c1caa1ebad9aa