### PR TITLE
Restore gallery image loading from database

### DIFF
--- a/PuzzleAM/CompletedPuzzle.cs
+++ b/PuzzleAM/CompletedPuzzle.cs
@@ -14,5 +14,12 @@ public class CompletedPuzzle
     public TimeSpan TimeToComplete { get; set; }
 
     [NotMapped]
-    public string ImageDataUrl => $"data:{ContentType};base64,{Convert.ToBase64String(ImageData)}";
+    public string ImageDataUrl
+    {
+        get
+        {
+            var contentType = string.IsNullOrWhiteSpace(ContentType) ? "image/png" : ContentType;
+            return $"data:{contentType};base64,{Convert.ToBase64String(ImageData)}";
+        }
+    }
 }

--- a/PuzzleAM/Components/Pages/Gallery.razor
+++ b/PuzzleAM/Components/Pages/Gallery.razor
@@ -1,5 +1,7 @@
 @page "/gallery"
 @rendermode InteractiveServer
+@using System
+@using System.Linq
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.EntityFrameworkCore
@@ -48,7 +50,7 @@
 </div>
 
 @code {
-    private List<CompletedPuzzle>? puzzles;
+    private List<GalleryPuzzle>? puzzles;
 
     protected override async Task OnInitializedAsync()
     {
@@ -59,19 +61,45 @@
             var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (userId is not null)
             {
-                puzzles = await Db.CompletedPuzzles
+                var results = await Db.CompletedPuzzles
+                    .AsNoTracking()
                     .Where(p => p.UserId == userId)
                     .OrderByDescending(p => p.Id)
+                    .Select(p => new CompletedPuzzleData(
+                        p.Id,
+                        p.PieceCount,
+                        p.TimeToComplete,
+                        p.ContentType,
+                        p.ImageData))
                     .ToListAsync();
+
+                puzzles = results
+                    .Where(p => p.ImageData is { Length: > 0 })
+                    .Select(p => new GalleryPuzzle(
+                        p.Id,
+                        p.PieceCount,
+                        p.TimeToComplete,
+                        BuildImageDataUrl(p.ImageData!, p.ContentType)))
+                    .ToList();
             }
             else
             {
-                puzzles = new List<CompletedPuzzle>();
+                puzzles = new List<GalleryPuzzle>();
             }
         }
         else
         {
-            puzzles = new List<CompletedPuzzle>();
+            puzzles = new List<GalleryPuzzle>();
         }
     }
+
+    private static string BuildImageDataUrl(byte[] imageData, string contentType)
+    {
+        var resolvedContentType = string.IsNullOrWhiteSpace(contentType) ? "image/png" : contentType;
+        return $"data:{resolvedContentType};base64,{Convert.ToBase64String(imageData)}";
+    }
+
+    private sealed record CompletedPuzzleData(int Id, int PieceCount, TimeSpan TimeToComplete, string ContentType, byte[]? ImageData);
+
+    private sealed record GalleryPuzzle(int Id, int PieceCount, TimeSpan TimeToComplete, string ImageDataUrl);
 }


### PR DESCRIPTION
## Summary
- ensure completed puzzles continue to require stored image bytes while defaulting the content type when missing
- hydrate gallery entries by materializing their image data directly from the database before building data URLs

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6b08162088320b25bc5c27763bfd9