### PR TITLE
Adjust gallery layout to show complete images

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -202,8 +202,8 @@ h1:focus {
 
 .gallery-grid {
     display: grid;
-    gap: 1.75rem;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .gallery-card {
@@ -226,18 +226,25 @@ h1:focus {
 .gallery-image {
     overflow: hidden;
     position: relative;
+    background: linear-gradient(180deg, rgba(241, 245, 249, 0.8), rgba(226, 232, 240, 0.6));
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 4 / 3;
 }
 
 .gallery-image img {
     display: block;
     width: 100%;
-    height: 220px;
-    object-fit: cover;
+    height: 100%;
+    object-fit: contain;
     transition: transform 0.35s ease;
 }
 
 .gallery-card:hover .gallery-image img {
-    transform: scale(1.04);
+    transform: scale(1);
+    filter: brightness(1.05);
 }
 
 .gallery-details {


### PR DESCRIPTION
## Summary
- tighten the gallery grid to allow 5-6 puzzle cards per row
- change gallery image container styling so puzzle images fit entirely within their cards
- replace the hover zoom with a brightness shift to avoid cropping

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6b97f137c8320acd664f0cf01676e