### PR TITLE
Reset puzzle state when loading new board

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -317,6 +317,19 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
     }
 
     [JSInvokable]
+    public Task PuzzleReset()
+    {
+        completionRecorded = false;
+        puzzleStarted = false;
+        stopwatch.Reset();
+        elapsed = TimeSpan.Zero;
+        timer?.Dispose();
+        timer = null;
+        isPuzzleLoading = true;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    [JSInvokable]
     public Task PuzzleLoading(bool loading)
     {
         isPuzzleLoading = loading;

--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -274,6 +274,7 @@ async function startHubConnection() {
 
     hubConnection.on("BoardState", state => {
         if (state.imageDataUrl) {
+            window.resetPuzzleState();
             window.createPuzzle(state.imageDataUrl, "puzzleContainer", state);
         }
     });
@@ -437,6 +438,13 @@ window.resetPuzzleState = function () {
     const container = document.getElementById('puzzleContainer');
     if (container) {
         container.innerHTML = '';
+    }
+    if (puzzleEventHandler) {
+        try {
+            puzzleEventHandler.invokeMethodAsync('PuzzleReset');
+        } catch (err) {
+            console.error('Error notifying puzzle reset', err);
+        }
     }
 };
 


### PR DESCRIPTION
## Summary
- reset the browser puzzle state before applying a new board so audio and flags restart
- notify the Blazor page when a puzzle resets to clear timers and completion tracking

## Testing
- Unable to run tests locally (dotnet CLI is not installed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6c07e7d88832085eb0b06eba5326a