### PR TITLE
Add gallery image removal control

### DIFF
--- a/PuzzleAM/Components/Pages/Gallery.razor
+++ b/PuzzleAM/Components/Pages/Gallery.razor
@@ -33,6 +33,10 @@
         {
             <article class="gallery-card">
                 <div class="gallery-image">
+                    <button type="button" class="gallery-remove" @onclick="() => RemovePuzzleAsync(p.Id)">
+                        <span aria-hidden="true">&times;</span>
+                        <span class="sr-only">Remove puzzle</span>
+                    </button>
                     <img src="@p.ImageDataUrl" alt="Completed puzzle" loading="lazy" />
                 </div>
                 <div class="gallery-details">
@@ -52,6 +56,7 @@
 
 @code {
     private List<GalleryPuzzle>? puzzles;
+    private string? userId;
 
     protected override async Task OnInitializedAsync()
     {
@@ -59,7 +64,7 @@
         var user = authState.User;
         if (user.Identity?.IsAuthenticated == true)
         {
-            var userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (userId is not null)
             {
                 var results = await Db.CompletedPuzzles
@@ -92,6 +97,29 @@
         {
             puzzles = new List<GalleryPuzzle>();
         }
+    }
+
+    private async Task RemovePuzzleAsync(int puzzleId)
+    {
+        if (puzzles is null || userId is null)
+        {
+            return;
+        }
+
+        var puzzle = await Db.CompletedPuzzles
+            .FirstOrDefaultAsync(p => p.Id == puzzleId && p.UserId == userId);
+
+        if (puzzle is null)
+        {
+            return;
+        }
+
+        Db.CompletedPuzzles.Remove(puzzle);
+        await Db.SaveChangesAsync();
+
+        puzzles = puzzles
+            .Where(p => p.Id != puzzleId)
+            .ToList();
     }
 
     private static string BuildImageDataUrl(byte[] imageData, string contentType)

--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -234,6 +234,38 @@ h1:focus {
     aspect-ratio: 4 / 3;
 }
 
+.gallery-remove {
+    position: absolute;
+    top: 0.65rem;
+    right: 0.65rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: none;
+    background: rgba(239, 68, 68, 0.92);
+    color: #fff;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 8px 20px -12px rgba(239, 68, 68, 0.9);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.gallery-remove:hover,
+.gallery-remove:focus-visible {
+    background: rgba(220, 38, 38, 0.98);
+    transform: scale(1.05);
+    box-shadow: 0 10px 22px -12px rgba(220, 38, 38, 0.9);
+    outline: none;
+}
+
+.gallery-remove:active {
+    transform: scale(0.97);
+}
+
 .gallery-image img {
     display: block;
     width: 100%;
@@ -272,6 +304,18 @@ h1:focus {
     font-weight: 600;
     color: #0f172a;
     font-variant-numeric: tabular-nums;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+    white-space: nowrap;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add a delete control to each gallery card that removes the puzzle from the database
- store the authenticated user's id for reuse during deletion
- style the remove button and add a reusable sr-only helper class

## Testing
- `dotnet test` *(fails: `dotnet` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c1d8d6608320a0cf9be7e82dbef9