### PR TITLE
Avoid resetting puzzle state on identical board updates

### DIFF
--- a/PuzzleAM/wwwroot/puzzle.js
+++ b/PuzzleAM/wwwroot/puzzle.js
@@ -273,10 +273,16 @@ async function startHubConnection() {
     });
 
     hubConnection.on("BoardState", state => {
-        if (state.imageDataUrl) {
-            window.resetPuzzleState();
-            window.createPuzzle(state.imageDataUrl, "puzzleContainer", state);
+        if (!state || !state.imageDataUrl) {
+            return;
         }
+
+        const isNewPuzzleImage = state.imageDataUrl !== window.currentImageDataUrl;
+        if (isNewPuzzleImage) {
+            window.resetPuzzleState();
+        }
+
+        window.createPuzzle(state.imageDataUrl, "puzzleContainer", state);
     });
 
     hubConnection.on("UserList", users => {


### PR DESCRIPTION
## Summary
- avoid triggering a full puzzle reset when a BoardState message arrives with the same image data
- continue rebuilding the puzzle layout while preserving timers and audio flags during reconnections

## Testing
- command failed: `dotnet test` (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6c77e47248320b3dccb93cdd94615