### PR TITLE
Stop showing loading overlay after puzzle reset

### DIFF
--- a/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
+++ b/PuzzleAM/Components/Pages/PuzzleGame.razor.cs
@@ -325,7 +325,11 @@ public partial class PuzzleGame : ComponentBase, IAsyncDisposable
         elapsed = TimeSpan.Zero;
         timer?.Dispose();
         timer = null;
-        isPuzzleLoading = true;
+        // When the puzzle state is cleared (for example after creating a new room or
+        // leaving one) there is no content to load yet, so the loading overlay should
+        // disappear. A fresh load will explicitly trigger the loading state through
+        // PuzzleLoading(true) once a puzzle is actually being prepared.
+        isPuzzleLoading = false;
         return InvokeAsync(StateHasChanged);
     }
 


### PR DESCRIPTION
## Summary
- stop forcing the puzzle loading overlay to stay visible after the puzzle state is cleared
- document the reason so future resets rely on explicit loading notifications from the client

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c701c0e48320b3c9ce3e4797324d