### PR TITLE
Adjust landing page title styling

### DIFF
--- a/PuzzleAM/wwwroot/app.css
+++ b/PuzzleAM/wwwroot/app.css
@@ -9,8 +9,6 @@ html, body {
 body {
     margin: 0;
     background-color: #ffffff;
-    background-image: repeating-conic-gradient( rgba(70, 205, 164, 0.2) 0% 25%, rgba(225, 101, 180, 0.2) 0% 50% );
-    background-size: 40px 40px;
 }
 
 a, .btn-link {
@@ -37,6 +35,8 @@ h1:focus {
 
 .landing-title {
     font-family: 'Cool Light Text Bubbles', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 5.5rem;
+    font-weight: 100;
 }
 
 .valid.modified:not([type=checkbox]) {


### PR DESCRIPTION
## Summary
- remove the checkered body background from the landing page stylesheet
- enlarge the landing title to 5.5rem and lighten the font weight to 100

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6d0291c44832081aae7ad81f491f4