### PR TITLE
Fix sidebar transition and tab alignment

### DIFF
--- a/PuzzleAM/Components/Layout/MainLayout.razor
+++ b/PuzzleAM/Components/Layout/MainLayout.razor
@@ -2,7 +2,7 @@
 @inject IJSRuntime JS
 
 
-<div class="page">
+<div class="page @(navOpen ? "nav-open" : "nav-closed")">
     <div class="sidebar @(navOpen ? string.Empty : "closed")">
         <NavMenu @bind-IsExpanded="navOpen" />
     </div>

--- a/PuzzleAM/Components/Layout/MainLayout.razor.css
+++ b/PuzzleAM/Components/Layout/MainLayout.razor.css
@@ -6,24 +6,34 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
 }
 
-main {
+.page main {
     flex: 1;
+    transition: margin-left 0.3s ease;
+}
+
+.page.nav-closed main {
+    margin-left: 0;
 }
 
 .sidebar {
     background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
     overflow: hidden;
-    transition: width 0.3s ease;
     width: var(--sidebar-width);
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    transform: translateX(0);
+    transition: transform 0.3s ease;
+    z-index: 1000;
 }
 
 .sidebar.closed {
-    width: 0;
     pointer-events: none;
-    position: fixed;
-    left: calc(var(--sidebar-width) * -1);
+    transform: translateX(calc(var(--sidebar-width) * -1));
 }
 
 @media (min-width: 641px) {
@@ -35,10 +45,12 @@ main {
         flex-direction: row;
     }
 
-    .sidebar {
-        height: 100vh;
-        position: sticky;
-        top: 0;
+    .page main {
+        width: 100%;
+    }
+
+    .page.nav-open main {
+        margin-left: var(--sidebar-width);
     }
 
     article {


### PR DESCRIPTION
## Summary
- add an open/closed state class to the layout container so content shifts with the sidebar
- switch the sidebar animation to use translateX so the tab remains aligned and the slide transition is smooth

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6d153da6c8320a43fc1e964ba71c3