### PR TITLE
Make home title responsive

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -4,7 +4,7 @@
 @inject IJSRuntime JS
 @inject NavigationManager Nav
 
-<h1 class="text-center fw-bold mt-5">Puzzle AM</h1>
+<h1 class="home-title text-center fw-bold mt-5">Puzzle AM</h1>
 <div class="d-flex flex-column align-items-center justify-content-center" style="height:70vh;">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>
     <div class="input-group w-auto mb-2">

--- a/PuzzleAM/Components/Pages/Home.razor.css
+++ b/PuzzleAM/Components/Pages/Home.razor.css
@@ -1,0 +1,12 @@
+.home-title {
+    font-size: clamp(2.5rem, 6vw, 6rem);
+    line-height: 1.1;
+    text-transform: uppercase;
+    letter-spacing: 0.25rem;
+}
+
+@media (max-width: 576px) {
+    .home-title {
+        letter-spacing: 0.15rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a scoped style for the home page title so that it scales with the viewport and appears in uppercase
- apply the scoped class to the home page heading to use the responsive sizing

## Testing
- dotnet build *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f82aae408320a4a0935abf4ff847