### PR TITLE
Style home page title responsively

### DIFF
--- a/PuzzleAM/Components/Pages/Home.razor
+++ b/PuzzleAM/Components/Pages/Home.razor
@@ -25,7 +25,7 @@
     }
 </div>
 
-<h1 class="text-center mt-5 landing-title">PUZZLE</h1>
+<h1 class="text-center mt-5 landing-title home-title">PUZZLE</h1>
 <img src="images/AM_logo.png" alt="Puzzle AM logo" class="d-block mx-auto" style="width:20vw; filter: drop-shadow(rgba(0, 0, 0, 0.9) 0px 3px 10px);" />
 <div class="d-flex flex-column align-items-center mt-3">
     <button class="btn btn-success mb-3" @onclick="CreateRoom">Create Room</button>

--- a/PuzzleAM/Components/Pages/Home.razor.css
+++ b/PuzzleAM/Components/Pages/Home.razor.css
@@ -1,0 +1,6 @@
+.home-title {
+    font-size: clamp(2.5rem, 8vw, 6rem);
+    letter-spacing: clamp(0.2rem, 1vw, 1.2rem);
+    text-transform: uppercase;
+    line-height: 1.1;
+}


### PR DESCRIPTION
## Summary
- add a scoped home-title class to the landing heading for better styling hooks
- create Home.razor.css to scale the title font size and letter spacing with viewport width

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fdbcd23883208adbc8818cd997f9